### PR TITLE
feat(chromealive): fix mouse events (mac only)

### DIFF
--- a/.github/workflows/boss.yml
+++ b/.github/workflows/boss.yml
@@ -27,8 +27,6 @@ jobs:
       - name: Install Hero
         run: yarn && yarn build
         working-directory: ./hero
-        env:
-          BROWSERS_DIR: /tmp/chromes
 
       - name: Install Databox
         run: yarn && yarn build
@@ -37,13 +35,7 @@ jobs:
       - name: Yarn build
         run: yarn && yarn build
 
-      - name: Zip Chromes
-        run: cd /tmp/chromes && tar -czf chromes.tar.gz ./*
-
-      - name: Copy Chrome
-        run: mkdir ./build/apps/boss/chromes && cp /tmp/chromes/chromes.tar.gz ./build/apps/boss/chromes/
-
-      - run: mkdir ~/.private-keys && echo "$APPLE_NOTARIZE_KEY" > ~/.private-keys/AuthKey_5VH6PQ3585.p8
+      - run: mkdir ~/.private_keys && echo "$APPLE_NOTARIZE_KEY" > ~/.private_keys/AuthKey_5VH6PQ3585.p8
         if: ${{ matrix.os == 'macos-latest' }}
         shell: bash
         env:

--- a/.github/workflows/boss.yml
+++ b/.github/workflows/boss.yml
@@ -43,12 +43,20 @@ jobs:
       - name: Copy Chrome
         run: mkdir ./build/apps/boss/chromes && cp /tmp/chromes/chromes.tar.gz ./build/apps/boss/chromes/
 
+      - run: mkdir ~/.private-keys && echo "$APPLE_NOTARIZE_KEY" > ~/.private-keys/AuthKey_5VH6PQ3585.p8
+        if: ${{ matrix.os == 'macos-latest' }}
+        shell: bash
+        env:
+          APPLE_NOTARIZE_KEY: ${{secrets.APPLE_NOTARIZE_KEY}}
+
       - name: Build Boss
         run: yarn dist
         working-directory: ./apps/boss
         env:
           USE_HARD_LINKS: false
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
 
       - name: Upload Boss
         if: ${{ github.ref != 'refs/heads/main' || failure() }}

--- a/apps/boss/assets/entitlements.mac.plist
+++ b/apps/boss/assets/entitlements.mac.plist
@@ -13,5 +13,6 @@
     <true/>
     <!-- https://github.com/electron-userland/electron-builder/issues/3940 -->
     <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
   </dict>
 </plist>

--- a/apps/boss/lib/Menubar.ts
+++ b/apps/boss/lib/Menubar.ts
@@ -6,12 +6,10 @@ import UlixeeServer from '@ulixee/server';
 import * as Positioner from 'electron-positioner';
 import * as Path from 'path';
 import ShutdownHandler from '@ulixee/commons/lib/ShutdownHandler';
-import * as Fs from 'fs';
-import * as Tar from 'tar';
-import { getCacheDirectory } from '@ulixee/commons/lib/dirUtils';
 import IMenubarOptions from '../interfaces/IMenubarOptions';
 import { getWindowPosition } from './util/getWindowPosition';
 import VueServer from './VueServer';
+import installDefaultChrome from './util/installDefaultChrome';
 
 // Forked from https://github.com/maxogden/menubar
 
@@ -29,7 +27,6 @@ export class Menubar extends EventEmitter {
   #positioner: Positioner | undefined;
   #vueServer: VueServer;
   #ulixeeServer: UlixeeServer;
-  #hasUnpackedChrome = false;
 
   constructor(options?: IMenubarOptions) {
     super();
@@ -292,7 +289,7 @@ export class Menubar extends EventEmitter {
     if (this.#ulixeeServer) return;
     this.#ulixeeServer = new UlixeeServer();
 
-    await this.tryUnpackEmbeddedChrome();
+    await installDefaultChrome();
 
     // TODO: read port from common ulixee.json? Or put running port into a file?
     await this.#ulixeeServer.listen({ port: 1337 });
@@ -320,59 +317,6 @@ export class Menubar extends EventEmitter {
       const evt = ${JSON.stringify(json)};
       document.dispatchEvent(new CustomEvent('boss:event', evt));
     })()`);
-    }
-  }
-
-  private async tryUnpackEmbeddedChrome(): Promise<void> {
-    if (this.#hasUnpackedChrome) return;
-    this.#hasUnpackedChrome = true;
-
-    let packagedChromesDir = `${__dirname}/../chromes`;
-
-    // if first run, need to see if we can unpack chromes
-    const chromeDir =
-      process.env.BROWSERS_DIR ?? Path.join(getCacheDirectory(), 'ulixee', 'chrome');
-
-    if (!Fs.existsSync(chromeDir)) Fs.mkdirSync(chromeDir, { recursive: true });
-
-    if (Fs.readdirSync(chromeDir).filter(x => !x.startsWith('.')).length) {
-      return;
-    }
-
-    // eslint-disable-next-line no-console
-    console.log(
-      'No $cachedir/ulixee/chrome directory exists, seeing if we can unpack from Boss package',
-    );
-
-    if (app.isPackaged) {
-      // app path is Boss.app/Content/Resources/app.asar on mac, boss/resources/app.asar on linux/win
-      let contentDir = Path.normalize(Path.join(app.getAppPath(), '..'));
-      if (Path.basename(contentDir).toLowerCase() === 'resources') {
-        contentDir = Path.normalize(Path.join(contentDir, '..'));
-      }
-
-      packagedChromesDir = `${contentDir}/chromes`;
-    }
-
-    if (!Fs.existsSync(packagedChromesDir)) {
-      // eslint-disable-next-line no-console
-      console.log('No packaged chromes directory exists at:', packagedChromesDir);
-      return;
-    }
-
-    for (const file of Fs.readdirSync(packagedChromesDir)) {
-      if (file.endsWith('.tar.gz')) {
-        // eslint-disable-next-line no-console
-        console.log('Got a Chrome package to unpack', file);
-        // @ts-ignore
-        await Tar.extract({
-          file: `${packagedChromesDir}/${file}`,
-          cwd: chromeDir,
-          sync: true,
-          strict: true,
-          preservePaths: true,
-        });
-      }
     }
   }
 }

--- a/apps/boss/lib/Menubar.ts
+++ b/apps/boss/lib/Menubar.ts
@@ -221,7 +221,7 @@ export class Menubar extends EventEmitter {
       transparent: true,
       alwaysOnTop: true,
       webPreferences: {
-        preload: `${__dirname}/preload.js`,
+        preload: `${__dirname}/PagePreload.js`,
       },
     });
 

--- a/apps/boss/lib/PagePreload.ts
+++ b/apps/boss/lib/PagePreload.ts
@@ -1,5 +1,7 @@
+// @ts-ignore
 const { ipcRenderer } = require('electron');
 
+// @ts-ignore
 document.addEventListener('boss:event', e => {
   // eslint-disable-next-line no-console
   console.log('boss:event', e);
@@ -7,6 +9,7 @@ document.addEventListener('boss:event', e => {
   ipcRenderer.send('boss:event', message.eventType, message.data);
 });
 
+// @ts-ignore
 document.addEventListener('boss:api', e => {
   // eslint-disable-next-line no-console
   console.log('boss:api', e);

--- a/apps/boss/lib/util/installDefaultChrome.ts
+++ b/apps/boss/lib/util/installDefaultChrome.ts
@@ -1,0 +1,20 @@
+import { latestBrowserEngineId } from '@ulixee/default-browser-emulator';
+
+let hasUnpackedChrome = false;
+export default async function installDefaultChrome(): Promise<void> {
+  if (hasUnpackedChrome) return;
+  try {
+    // eslint-disable-next-line global-require,import/no-dynamic-require
+    let LatestChrome = require(`@ulixee/${latestBrowserEngineId}`);
+    if (LatestChrome.default) LatestChrome = LatestChrome.default;
+    const chromeApp = new LatestChrome();
+    if (chromeApp.isInstalled) {
+      hasUnpackedChrome = true;
+      return;
+    }
+    await chromeApp.install();
+    hasUnpackedChrome = true;
+  } catch (err) {
+    console.error('ERROR trying to install latest browser', err);
+  }
+}

--- a/apps/boss/package.json
+++ b/apps/boss/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "build": "yarn build:ui && yarn build:basic && cd ../../build/apps/boss && yarn && electron-builder install-app-deps",
-    "build:basic": "cd ../.. && yarn tsc && cd apps/boss && yarn copy:build",
+    "build:basic": "cd ../.. && yarn run tsc && cd apps/boss && yarn copy:build",
     "build:ui": "yarn workspace @ulixee/apps-menubar-ui build && yarn workspace @ulixee/apps-chromealive-ui build",
     "copy:build": "cd ../../build/apps/boss && node builder/copySources.js ./packages",
     "dist": "yarn build && cd ../../build/apps/boss && yarn && electron-builder --publish onTagOrDraft",
@@ -21,13 +21,25 @@
     "electron-positioner": "^4.1.0",
     "tar": "^6.1.10",
     "node-static": "^0.7.11",
+    "debug": "^4.3.2",
     "tslib": "^2.3.1",
     "electron-log": "^4.4.1",
     "debug": "^4.3.2"
   },
+  "devDependencies": {
+    "electron": "13.1.7",
+    "electron-builder": "^22.11.11",
+    "shx": "^0.3.3",
+    "cross-env": "^7.0.3",
+    "electron-notarize": "^1.1.0"
+  },
+  "optionalDependencies": {
+    "nseventmonitor": "^1.0.0"
+  },
   "build": {
     "appId": "dev.ulixee.boss",
     "productName": "Ulixee Boss",
+    "afterSign": "scripts/notarize.js",
     "asarUnpack": [
       "node_modules/@ulixee/apps-chromealive-core"
     ],
@@ -64,16 +76,6 @@
       "provider": "github",
       "releaseType": "release"
     }
-  },
-  "devDependencies": {
-    "electron": "13.1.7",
-    "electron-builder": "^22.11.11",
-    "shx": "^0.3.3",
-    "cross-env": "^7.0.3",
-    "electron-notarize": "^1.1.0"
-  },
-  "optionalDependencies": {
-    "nseventmonitor": "^1.0.0"
   },
   "nohoist": [
     "**/electron",

--- a/apps/boss/package.json
+++ b/apps/boss/package.json
@@ -16,6 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "@ulixee/apps-chromealive-core": "1.5.4",
+    "@ulixee/default-browser-emulator": "1.5.4",
     "@ulixee/commons": "1.5.5",
     "@ulixee/server": "1.5.4",
     "electron-positioner": "^4.1.0",

--- a/apps/boss/scripts/notarize.ts
+++ b/apps/boss/scripts/notarize.ts
@@ -3,7 +3,7 @@ import { notarize } from 'electron-notarize';
 export default async function notarizing(context) {
   const { electronPlatformName, appOutDir } = context;
 
-  if (electronPlatformName !== 'darwin' || !process.env.NOTARIZE) {
+  if (electronPlatformName !== 'darwin' || process.env.SKIP_NOTARIZE) {
     return;
   }
 

--- a/apps/boss/scripts/notarize.ts
+++ b/apps/boss/scripts/notarize.ts
@@ -2,7 +2,8 @@ import { notarize } from 'electron-notarize';
 
 export default async function notarizing(context) {
   const { electronPlatformName, appOutDir } = context;
-  if (electronPlatformName !== 'darwin') {
+
+  if (electronPlatformName !== 'darwin' || !process.env.NOTARIZE) {
     return;
   }
 
@@ -11,7 +12,9 @@ export default async function notarizing(context) {
   return await notarize({
     appBundleId: 'dev.ulixee.boss',
     appPath: `${appOutDir}/${appName}.app`,
-    appleId: process.env.APPLEID,
-    appleIdPassword: process.env.APPLEIDPASS,
+    appleApiKey: '5VH6PQ3585',
+    appleApiKeyId: '5VH6PQ3585',
+    appleApiIssuer: 'a89474ed-637f-4cf0-8429-da45ef388882',
+    teamId: 'DY8K483XWV',
   });
 }

--- a/apps/chromealive-core/apis/App.boundsChanged.ts
+++ b/apps/chromealive-core/apis/App.boundsChanged.ts
@@ -5,6 +5,6 @@ import {
 import AliveBarPositioner from '../lib/AliveBarPositioner';
 
 export default function appBoundsChangedApi(args: IAppBoundsChangedArgs): IAppBoundsChangedResult {
-  AliveBarPositioner.onAppBoundsChanged(args.workarea, args.toolbarBounds);
+  AliveBarPositioner.onAppBoundsChanged(args.bounds);
   return {};
 }

--- a/apps/chromealive-core/apis/App.ready.ts
+++ b/apps/chromealive-core/apis/App.ready.ts
@@ -1,0 +1,6 @@
+import { IAppReadyArgs } from '@ulixee/apps-chromealive-interfaces/apis/IAppReadyApi';
+import AliveBarPositioner from '../lib/AliveBarPositioner';
+
+export default function appReadyApi(args: IAppReadyArgs): void {
+  AliveBarPositioner.onAppReady(args.workarea);
+}

--- a/apps/chromealive-core/apis/Mouse.state.ts
+++ b/apps/chromealive-core/apis/Mouse.state.ts
@@ -1,0 +1,6 @@
+import { IMouseStateArgs } from '@ulixee/apps-chromealive-interfaces/apis/IMouseStateApi';
+import AliveBarPositioner from '../lib/AliveBarPositioner';
+
+export default function mouseStateApi(args: IMouseStateArgs): void {
+  AliveBarPositioner.setMouseDown(args.isMousedown);
+}

--- a/apps/chromealive-core/apis/index.ts
+++ b/apps/chromealive-core/apis/index.ts
@@ -3,6 +3,8 @@ import sessionResumeApi from './Session.resume';
 import sessionStepApi from './Session.step';
 import sessionUrlScreenshotApi from './Session.urlScreenshot';
 import appBoundsChangedApi from './App.boundsChanged';
+import appReadyApi from './App.ready';
+import mouseStateApi from './Mouse.state';
 
 // README:
 // This wiring makes sure the args/result match the api definitions
@@ -18,6 +20,8 @@ const apiHandlers: ApiHandlers = {
   'Session.step': sessionStepApi,
   'Session.urlScreenshot': sessionUrlScreenshotApi,
   'App.boundsChanged': appBoundsChangedApi,
+  'App.ready': appReadyApi,
+  'Mouse.state': mouseStateApi,
 };
 
 export { apiHandlers };

--- a/apps/chromealive-core/lib/ConnectionToClient.ts
+++ b/apps/chromealive-core/lib/ConnectionToClient.ts
@@ -8,7 +8,6 @@ import IChromeAliveApis, {
 import { apiHandlers } from '../apis';
 
 export default class ConnectionToClient extends TypedEventEmitter<{
-  connected: void;
   message: IChromeAliveApiResponse<any> | IChromeAliveEvent<any>;
   close: void;
 }> {

--- a/apps/chromealive-interfaces/apis/IAppBoundsChangedApi.ts
+++ b/apps/chromealive-interfaces/apis/IAppBoundsChangedApi.ts
@@ -13,9 +13,7 @@ export interface IBounds {
 }
 
 export interface IAppBoundsChangedArgs {
-  workarea: IBounds;
-  appBounds: IBounds;
-  toolbarBounds: IBounds;
+  bounds: IBounds;
 }
 
 export interface IAppBoundsChangedResult {

--- a/apps/chromealive-interfaces/apis/IAppReadyApi.ts
+++ b/apps/chromealive-interfaces/apis/IAppReadyApi.ts
@@ -1,0 +1,11 @@
+import IChromeAliveApi from './IChromeAliveApi';
+import { IBounds } from './IAppBoundsChangedApi';
+
+export default interface IAppReadyApi extends IChromeAliveApi {
+  args: IAppReadyArgs;
+  result: void;
+}
+
+export interface IAppReadyArgs {
+  workarea: IBounds;
+}

--- a/apps/chromealive-interfaces/apis/IMouseStateApi.ts
+++ b/apps/chromealive-interfaces/apis/IMouseStateApi.ts
@@ -1,0 +1,10 @@
+import IChromeAliveApi from './IChromeAliveApi';
+
+export default interface IMouseStateApi extends IChromeAliveApi {
+  args: IMouseStateArgs;
+  result: void;
+}
+
+export interface IMouseStateArgs {
+  isMousedown: boolean;
+}

--- a/apps/chromealive-interfaces/apis/index.ts
+++ b/apps/chromealive-interfaces/apis/index.ts
@@ -2,12 +2,16 @@ import ISessionResumeApi from './ISessionResumeApi';
 import ISessionStepApi from './ISessionStepApi';
 import ISessionUrlScreenshotApi from './ISessionUrlScreenshotApi';
 import IAppBoundsChangedApi from './IAppBoundsChangedApi';
+import IAppReadyApi from './IAppReadyApi';
+import IMouseStateApi from './IMouseStateApi';
 
 export default interface IChromeAliveApis {
   'Session.resume': ISessionResumeApi;
   'Session.step': ISessionStepApi;
   'Session.urlScreenshot': ISessionUrlScreenshotApi;
   'App.boundsChanged': IAppBoundsChangedApi;
+  'App.ready': IAppReadyApi;
+  'Mouse.state': IMouseStateApi;
 }
 
 export interface IChromeAliveApiRequest<T extends keyof IChromeAliveApis> {

--- a/apps/chromealive/lib/ChromeAliveApi.ts
+++ b/apps/chromealive/lib/ChromeAliveApi.ts
@@ -1,0 +1,97 @@
+import { Serializable } from 'child_process';
+import IChromeAliveApis, {
+  IChromeAliveApiResponse,
+} from '@ulixee/apps-chromealive-interfaces/apis';
+import IChromeAliveEvents from '@ulixee/apps-chromealive-interfaces/events';
+import * as WebSocket from 'ws';
+import TypeSerializer from '@ulixee/commons/lib/TypeSerializer';
+import IChromeAliveEvent from '@ulixee/apps-chromealive-interfaces/events/IChromeAliveEvent';
+
+type IEvent = keyof IChromeAliveEvents;
+
+export default class ChromeAliveApi {
+  private pendingMessagesById = new Map<string, (args: any) => any>();
+  private messageCounter = 0;
+  private webSocket: WebSocket;
+
+  constructor(
+    private chromeAliveServerApi: string,
+    public onEvent: (event: IEvent, data?: IChromeAliveEvents[IEvent]) => any,
+  ) {
+    process.on('disconnect', () => this.onEvent('App.quit'));
+    process.on('message', this.onMessage.bind(this));
+  }
+
+  public async connect() {
+    const webSocket = new WebSocket(this.chromeAliveServerApi);
+    this.webSocket = webSocket;
+    await new Promise<WebSocket | Error>(resolve => {
+      function onError(error: Error): void {
+        if (error instanceof Error) resolve(error);
+        else resolve(new Error(`Error connecting to Websocket host -> ${error}`));
+      }
+
+      webSocket.once('close', onError);
+      webSocket.once('error', onError);
+      webSocket.once('open', () => {
+        webSocket.off('error', onError);
+        webSocket.off('close', onError);
+        resolve(webSocket);
+      });
+    });
+    webSocket.on('message', message => {
+      const payload = TypeSerializer.parse(message.toString(), 'REMOTE CORE');
+      this.onMessage(payload);
+    });
+  }
+
+  public close() {
+    if (this.webSocket?.readyState === WebSocket.OPEN) {
+      try {
+        this.webSocket.terminate();
+      } catch (_) {
+        // ignore errors terminating
+      }
+    }
+  }
+
+  public async send<T extends keyof IChromeAliveApis>(
+    api: T,
+    args: IChromeAliveApis[T]['args'],
+  ): Promise<IChromeAliveApis[T]['result']> {
+    if (this.webSocket?.readyState !== WebSocket.OPEN) {
+      throw new Error('Websocket was not open');
+    }
+
+    const messageId = String((this.messageCounter += 1));
+    const promise = new Promise(resolve => {
+      this.pendingMessagesById.set(messageId, resolve);
+    });
+    const message = TypeSerializer.stringify({
+      api,
+      messageId,
+      args,
+    });
+
+    this.webSocket.send(message);
+    const result = await promise;
+    if (result instanceof Error) throw result;
+    return result;
+  }
+
+  private onMessage(message: Serializable) {
+    if (message === 'exit') {
+      this.onEvent('App.quit');
+      return;
+    }
+    const apiResponse = message as IChromeAliveApiResponse<any>;
+    if (apiResponse.responseId) {
+      const callback = this.pendingMessagesById.get(apiResponse.responseId);
+      this.pendingMessagesById.delete(apiResponse.responseId);
+      if (callback) callback(apiResponse.result);
+    } else {
+      const apiEvent = message as IChromeAliveEvent<any>;
+      this.onEvent(apiEvent.eventType, apiEvent.data);
+    }
+  }
+}

--- a/apps/chromealive/lib/PagePreload.ts
+++ b/apps/chromealive/lib/PagePreload.ts
@@ -1,5 +1,10 @@
+// @ts-ignore
 const { ipcRenderer } = require('electron');
 
+// @ts-ignore
+window.addEventListener('mousemove', () => ipcRenderer.send('mousemove'), { capture: false });
+
+// @ts-ignore
 document.addEventListener('chromealive:event', e => {
   // eslint-disable-next-line no-console
   console.log('chromealive:event', e);
@@ -7,9 +12,18 @@ document.addEventListener('chromealive:event', e => {
   ipcRenderer.send('chromealive:event', message.eventType, message.data);
 });
 
+// @ts-ignore
 document.addEventListener('chromealive:api', e => {
   // eslint-disable-next-line no-console
   console.log('chromealive:api', e);
   const message = e.detail;
   ipcRenderer.send('chromealive:api', message.api, message.args);
+});
+
+// @ts-ignore
+document.addEventListener('app:height-changed', e => {
+  // eslint-disable-next-line no-console
+  console.log('app:height-changed', e);
+  const message = e.detail;
+  ipcRenderer.send('resize-height', message.height);
 });

--- a/apps/chromealive/package.json
+++ b/apps/chromealive/package.json
@@ -27,7 +27,12 @@
     "compare-versions": "^3.6.0",
     "electron-log": "^4.4.1",
     "@ulixee/commons": "^1.5.5",
-    "electron-context-menu": "^3.1.1"
+    "@ulixee/apps-chromealive-interfaces": "^1.5.4",
+    "electron-context-menu": "^3.1.1",
+    "ws": "^7.4.4"
+  },
+  "optionalDependencies": {
+    "nseventmonitor": "^1.0.0"
   },
   "devDependencies": {
     "@types/tar": "^4.0.5",

--- a/server/main/lib/ChromeAliveCoreConnector.ts
+++ b/server/main/lib/ChromeAliveCoreConnector.ts
@@ -29,7 +29,7 @@ export default class ChromeAliveCoreConnector extends BaseCoreConnector {
 
   private onConnection(ws: WebSocket) {
     const ChromeAliveCore = ChromeAliveCoreConnector.getChromeAlive();
-    const connection = ChromeAliveCore.getConnection();
+    const connection = ChromeAliveCore.addConnection();
     ws.on('message', message => {
       const payload = TypeSerializer.parse(message.toString(), 'CLIENT');
       return connection.handleRequest(payload);
@@ -45,7 +45,6 @@ export default class ChromeAliveCoreConnector extends BaseCoreConnector {
         sendWsCloseUnexpectedError(ws, error.message);
       }
     });
-    connection.emit('connected');
   }
 
   public static isInstalled(): boolean {


### PR DESCRIPTION
This PR changes slightly how ChromeAlive connections work - both the app and the ui now connect to the backend. App listens for mouse events and sends them to Core and sends the workarea on startup now.

Features:
- Add notarizing and signing to mac app packages.
- Install chrome on first launch (not pre-packaged, since that breaks signing)
- Let user drag chrome window wherever they want; only readjust after drag has stopped
- Hovers not working for playbar if chromealive isn't focused
- chrome extension turns off randomly?  (wasn't activating in time sometimes)