### PR TITLE
feat(chromealive): fix focus of databox panel

### DIFF
--- a/apps/chromealive-core/chrome-extension/background.ts
+++ b/apps/chromealive-core/chrome-extension/background.ts
@@ -40,52 +40,72 @@ chrome.runtime.onConnect.addListener(port => {
   }
 });
 
+async function postToTab(tabId: number, message: any, isRetry = false): Promise<boolean> {
+  try {
+    const port = await connectToTab(tabId);
+    if (port) {
+      port.postMessage(message);
+      return true;
+    }
+  } catch (e) {
+    if (String(e).match(/Attempting to use a disconnected port object/)) {
+      portsByTabId[tabId] = null;
+      if (!isRetry) return postToTab(tabId, message, true);
+    }
+    logDebug('Error connecting to tab', { tabId, e });
+  }
+  return false;
+}
+
 /////// FOCUSED WINDOW + BOUNDS ////////////////////////////////////////////////////////////////////////////////////////
 
 function getActiveTabs(windowId: number): Promise<chrome.tabs.Tab[]> {
   return chrome.tabs.query({ active: true, windowId });
 }
 
-async function broadcastBounds(window: chrome.windows.Window) {
-  const activeTabs = await getActiveTabs(window.id);
-  const windowBounds = {
-    windowId: window.id,
-    left: window.left,
-    top: window.top,
-    width: window.width,
-    height: window.height,
-  };
-
-  logDebug(`Window ${window.id} bounds changed to`, windowBounds);
-
-  for (const tab of activeTabs) {
-    try {
-      const port = await connectToTab(tab.id);
-      if (port) {
-        port.postMessage({ windowBounds });
-        return;
-      }
-    } catch (e) {
-      logDebug('Error connecting to tab (broadcastBounds)', { tab, e });
-    }
-  }
-}
-
-async function broadcastActive(windowId: number) {
-  logDebug(`Window focus changed to ${windowId}`);
+async function broadcast(windowId: number, message: any): Promise<void> {
+  logDebug(`Broadcasting to ${windowId}`, message);
 
   // don't update on blur for now (devtools and chromealive bar steal focus!)
   if (windowId === -1) return;
 
   const activeTabs = await getActiveTabs(windowId);
   for (const tab of activeTabs) {
-    try {
-      const port = await connectToTab(tab.id);
-      port?.postMessage({ active: true });
-    } catch (e) {
-      logDebug('Error connecting to tab (broadcastActive)', { tab, e });
-    }
+    await postToTab(tab.id, message);
   }
+}
+
+async function broadcastBounds(window: chrome.windows.Window) {
+  const message = {
+    windowBounds: {
+      windowId: window.id,
+      left: window.left,
+      top: window.top,
+      width: window.width,
+      height: window.height,
+    },
+  };
+
+  const activeTabs = await getActiveTabs(window.id);
+  for (const tab of activeTabs) {
+    const didPost = await postToTab(tab.id, message);
+    if (didPost) return;
+  }
+}
+
+async function broadcastActive(windowId: number): Promise<void> {
+  const message = { active: true, focused: true };
+
+  if (windowId === -1) {
+    const lastFocused = await chrome.windows.getLastFocused();
+    windowId = lastFocused.id;
+    message.focused = false;
+  }
+  return broadcast(windowId, message);
+}
+
+function broadcastGroupOpened(windowId: number): Promise<void> {
+  return broadcast(windowId, { tabGroupOpened: true });
 }
 
 chrome.windows.onBoundsChanged.addListener(broadcastBounds);
@@ -97,9 +117,13 @@ chrome.windows.onCreated.addListener(async window => {
 });
 chrome.windows.onFocusChanged.addListener(broadcastActive);
 chrome.tabs.onActivated.addListener(tab => broadcastActive(tab.windowId));
+chrome.tabGroups.onUpdated.addListener(group => {
+  if (isCreatingGroup) return;
+  if (group.collapsed === false) return broadcastGroupOpened(group.windowId);
+});
 
 /////// DEVTOOLS DRIVER ////////////////////////////////////////////////////////////////////////////////////////////////
-
+let isCreatingGroup = false;
 const RuntimeActions = {
   identify(
     message: any,
@@ -119,26 +143,33 @@ const RuntimeActions = {
       chrome.tabGroups.query({ windowId, title }, resolve),
     );
 
-    let groupId = matchingGroups[0]?.id;
-    if (groupId) {
-      await chrome.tabs.group({
-        groupId,
-        tabIds,
-      });
-    } else {
-      groupId = await chrome.tabs.group({
-        createProperties: {
-          windowId,
-        },
-        tabIds,
-      });
+    isCreatingGroup = true;
+    try {
+      let groupId = matchingGroups[0]?.id;
+      if (groupId) {
+        await chrome.tabs.group({
+          groupId,
+          tabIds,
+        });
+      } else {
+        groupId = await chrome.tabs.group({
+          createProperties: {
+            windowId,
+          },
+          tabIds,
+        });
+      }
+
+      logDebug(
+        `Updated group tabIds=${tabIds.join(',')}, windowId=${windowId}, groupId=${groupId}`,
+      );
+      await chrome.tabGroups.update(groupId, { title, color, collapsed });
+      logDebug(`Updated group props=${message}`);
+
+      return { groupId };
+    } finally {
+      setTimeout(() => (isCreatingGroup = false), 200);
     }
-
-    logDebug(`Updated group tabIds=${tabIds.join(',')}, windowId=${windowId}, groupId=${groupId}`);
-    await chrome.tabGroups.update(groupId, { title, color, collapsed });
-    logDebug(`Updated group props=${message}`);
-
-    return { groupId };
   },
   async ungroupTabs(message: { tabIds: number[] }): Promise<void> {
     logDebug(`Ungrouping tabIds=${message.tabIds?.join(',')}`);

--- a/apps/chromealive-core/chrome-extension/content-script.ts
+++ b/apps/chromealive-core/chrome-extension/content-script.ts
@@ -1,8 +1,8 @@
 declare let window: Window;
 
-function onPageVisible(): void {
+function onPageVisible(isFocused = true): void {
   // @ts-ignore
-  if (window.___onPageVisible) window.___onPageVisible('');
+  if (window.___onPageVisible) window.___onPageVisible(JSON.stringify({ focused: isFocused }));
 }
 
 function onBoundsChanged(bounds: {
@@ -21,9 +21,16 @@ function onTabIdentify(id: { tabId: number; windowId: number }): void {
   if (window.___onTabIdentify) window.___onTabIdentify(JSON.stringify(id));
 }
 
+function onTabGroupOpened(): void {
+  // @ts-ignore
+  if (window.___onTabGroupOpened) window.___onTabGroupOpened('');
+}
+
 function onMessage(message) {
   if ('active' in message) {
-    onPageVisible();
+    onPageVisible(message.focused);
+  } else if ('tabGroupOpened' in message) {
+    onTabGroupOpened();
   } else if ('windowBounds' in message) {
     onBoundsChanged(message.windowBounds);
   } else if ('tabId' in message) {

--- a/apps/chromealive-core/hero-plugins/FocusedWindowCorePlugin.ts
+++ b/apps/chromealive-core/hero-plugins/FocusedWindowCorePlugin.ts
@@ -32,23 +32,32 @@ export default class FocusedWindowCorePlugin extends CorePlugin {
       page.addNewDocumentScript(
         `document.addEventListener('visibilitychange', function() {
     const state = document.visibilityState;
-    if (state === 'visible') ___onPageVisible('');
+    if (state === 'visible') ___onPageVisible('{ "focused": true, "active": true }');
   }, false)`,
         true,
       ),
     ]);
   }
 
-  onPageVisible(sessionId: string, puppetPageId: string) {
-    FocusedWindowCorePlugin.onVisibilityChange(true, sessionId, puppetPageId);
+  onPageVisible(sessionId: string, puppetPageId: string, statusJson: string) {
+    const status = JSON.parse(statusJson ?? '{}');
+    FocusedWindowCorePlugin.onVisibilityChange(
+      { active: true, focused: status.focused },
+      sessionId,
+      puppetPageId,
+    );
   }
 
   onPageClosed(sessionId: string, puppetPageId: string): void {
-    FocusedWindowCorePlugin.onVisibilityChange(false, sessionId, puppetPageId);
+    FocusedWindowCorePlugin.onVisibilityChange(
+      { active: false, focused: false },
+      sessionId,
+      puppetPageId,
+    );
   }
 
   public static onVisibilityChange: (
-    isVisible: boolean,
+    status: { focused: boolean; active: boolean },
     sessionId: string,
     puppetPageId: string,
   ) => any = () => null;

--- a/apps/chromealive-core/index.ts
+++ b/apps/chromealive-core/index.ts
@@ -171,10 +171,11 @@ export default class ChromeAliveCore {
   }
 
   private static async changeActiveSessions(
-    isPageVisible: boolean,
+    status: { focused: boolean; active: boolean },
     heroSessionId: string,
     pageId: string,
   ): Promise<void> {
+    const isPageVisible = status.active;
     log.info('Changing active session', { isPageVisible, sessionId: heroSessionId, pageId });
     const sessionObserver = this.sessionObserversById.get(heroSessionId);
     if (!sessionObserver) return;
@@ -200,7 +201,11 @@ export default class ChromeAliveCore {
       this.activeHeroSessionId = heroSessionId;
     }
 
-    this.toggleAppVisibility(!!this.activeHeroSessionId);
+    if (status.focused === false) {
+      this.toggleAppTop(status.focused);
+    } else {
+      this.toggleAppVisibility(!!this.activeHeroSessionId);
+    }
   }
 
   private static getSessionDevtools(heroSessionId: string): IDevtoolsSession {
@@ -255,6 +260,10 @@ export default class ChromeAliveCore {
     this.app?.send('exit');
     this.app?.kill('SIGTERM');
     this.app = null;
+  }
+
+  private static toggleAppTop(isFocused: boolean): void {
+    this.sendEvent('App.onTop', isFocused);
   }
 
   private static toggleAppVisibility(show: boolean): void {

--- a/apps/chromealive-core/lib/SessionObserver.ts
+++ b/apps/chromealive-core/lib/SessionObserver.ts
@@ -256,7 +256,15 @@ export default class SessionObserver extends TypedEventEmitter<{
 
     const pages = [...this.heroSession.tabsById.values()].map(x => x.puppetPage);
     if (groupLive === false) await tabGroupPlugin.ungroupTabs(pages);
-    else await tabGroupPlugin.groupTabs(pages, 'Reopen Live', 'blue', true);
+    else {
+      await tabGroupPlugin.groupTabs(
+        pages,
+        'Reopen Live',
+        'blue',
+        true,
+        this.closeReplay.bind(this),
+      );
+    }
   }
 
   private onFileUpdated(stats: Fs.Stats): void {

--- a/apps/chromealive-interfaces/events/index.ts
+++ b/apps/chromealive-interfaces/events/index.ts
@@ -5,6 +5,7 @@ export default interface IChromeAliveEvents {
   'App.show': null;
   'App.hide': null;
   'App.quit': null;
+  'App.onTop': boolean;
   'Session.loading': void;
   'Session.loaded': void;
   'Session.active': IHeroSessionActiveEvent;

--- a/apps/chromealive-ui/src/pages/app/index.vue
+++ b/apps/chromealive-ui/src/pages/app/index.vue
@@ -432,13 +432,13 @@ export default class ChromeAliveApp extends Vue {
   onSessionActiveEvent(message: IHeroSessionActiveEvent) {
     const isNewId = message.heroSessionId !== this.session.heroSessionId || !message.heroSessionId;
     Object.assign(this.session, message);
-    if (isNewId) {
+    this.isHistoryMode = this.session.playbackState === 'history';
+
+    if (isNewId || !this.isHistoryMode) {
       this.nibLeft = '100%';
       this.selectedNavigationId = null;
       this.timelineHover.show = false;
     }
-
-    this.isHistoryMode = this.session.playbackState === 'history';
 
     this.updateScriptTimeAgo();
 

--- a/apps/chromealive/lib/ChromeAlive.ts
+++ b/apps/chromealive/lib/ChromeAlive.ts
@@ -248,13 +248,23 @@ export class ChromeAlive extends EventEmitter {
     await this.#api.send('App.ready', { workarea: workareaBounds });
   }
 
+  private toggleOnTop(onTop: boolean) {
+    for (const window of this.#childWindows) {
+      window.setAlwaysOnTop(onTop);
+    }
+  }
+
   private onChromeAliveEvent<T extends keyof IChromeAliveEvents>(
     eventType: T,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     data: IChromeAliveEvents[T],
   ): void {
     if (eventType === 'App.hide') this.hideWindow();
-    if (eventType === 'App.show') this.showWindow();
+    if (eventType === 'App.show') {
+      this.showWindow();
+      this.toggleOnTop(true);
+    }
+    if (eventType === 'App.onTop') this.toggleOnTop(data as boolean);
     if (eventType === 'App.quit') app.exit();
   }
 }


### PR DESCRIPTION
Fixes 2 issues:
1) When you click Reopen Replay, it switches back to live mode
2) The databox panel goes away when you click off of chromealive