### PR TITLE
Page State UX Changes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+.eslintrc.js
+*.config.js
+tsconfig*.json

--- a/apps/chromealive-core/apis/PageStateApi.ts
+++ b/apps/chromealive-core/apis/PageStateApi.ts
@@ -46,7 +46,12 @@ export default class PageStateApi {
     if (!pageStateManager.isShowingSession(args.heroSessionId)) {
       await pageStateManager.openTimetravel(args.heroSessionId);
     }
-    await pageStateManager.changeSessionTimeBoundary(args.timelineOffset, args.isStartTime);
+    await pageStateManager.changeSessionLoadingTimeBoundary(args.timelineOffset, args.isStartTime);
+  }
+
+  static async extendSessionTime(args: { heroSessionId: string; addMillis: number }): Promise<void> {
+    const pageStateManager = getPageStateManager();
+    await pageStateManager.extendSessionTime(args.heroSessionId, args.addMillis);
   }
 
   static async focusSessionTime(args: {
@@ -57,7 +62,7 @@ export default class PageStateApi {
     if (!pageStateManager.isShowingSession(args.heroSessionId)) {
       await pageStateManager.openTimetravel(args.heroSessionId);
     }
-    await pageStateManager.focusSessionTimeBoundary(args.isStartTime);
+    await pageStateManager.focusSessionLoadingTimeBoundary(args.isStartTime);
   }
 
   static save(): Promise<{ needsCodeChange: boolean; code: string }> {

--- a/apps/chromealive-core/apis/SessionApi.ts
+++ b/apps/chromealive-core/apis/SessionApi.ts
@@ -3,7 +3,6 @@ import {
   ISessionApiStatics,
   ISessionResumeArgs,
 } from '@ulixee/apps-chromealive-interfaces/apis/ISessionApi';
-import TimelineBuilder from '@ulixee/hero-timetravel/player/TimelineBuilder';
 import SessionObserver from '../lib/SessionObserver';
 import ChromeAliveCore from '../index';
 
@@ -12,7 +11,7 @@ export default class SessionApi {
   static getScreenshot(args: IHeroSessionArgs & { tabId: number; timestamp: number }): {
     imageBase64: string;
   } {
-    const timelineBuilder = TimelineBuilder.bySessionId.get(args.heroSessionId);
+    const timelineBuilder = getObserver().getTimelineBuilder(args.heroSessionId);
     return { imageBase64: timelineBuilder.getScreenshot(args.tabId, args.timestamp) };
   }
 
@@ -65,8 +64,8 @@ export default class SessionApi {
   }
 }
 
-function getObserver(args: IHeroSessionArgs): SessionObserver {
-  const sessionId = args.heroSessionId ?? ChromeAliveCore.activeHeroSessionId;
+function getObserver(args?: IHeroSessionArgs): SessionObserver {
+  const sessionId = args?.heroSessionId ?? ChromeAliveCore.activeHeroSessionId;
   if (!sessionId || !ChromeAliveCore.sessionObserversById.has(sessionId))
     throw new Error(`No active session found - sessionId: "${sessionId}"`);
 

--- a/apps/chromealive-core/apis/index.ts
+++ b/apps/chromealive-core/apis/index.ts
@@ -16,6 +16,7 @@ const ApiHandlers: IApiHandlerSpec = {
   'PageState.spawnSession': PageStateApi.spawnSession,
   'PageState.modifySessionTimes': PageStateApi.modifySessionTimes,
   'PageState.focusSessionTime': PageStateApi.focusSessionTime,
+  'PageState.extendSessionTime': PageStateApi.extendSessionTime,
   'PageState.unfocusSession': PageStateApi.unfocusSession,
   'PageState.openSession': PageStateApi.openSession,
   'PageState.save': PageStateApi.save,

--- a/apps/chromealive-core/lib/HeroCorePlugin.ts
+++ b/apps/chromealive-core/lib/HeroCorePlugin.ts
@@ -108,9 +108,5 @@ export default class HeroCorePlugin extends CorePlugin {
   ): Promise<any> {
     const { targetInfo } = event;
     if (targetInfo.url !== `chrome-extension://${extensionId}/background.js`) return;
-    devtoolsSession.on('Runtime.consoleAPICalled', ev =>
-      this.logger.stats('ServiceWorker.Console', { args: ev.args }),
-    );
-    return Promise.all([devtoolsSession.send('Runtime.enable').catch(console.error)]);
   }
 }

--- a/apps/chromealive-core/lib/PageStateManager.ts
+++ b/apps/chromealive-core/lib/PageStateManager.ts
@@ -1,6 +1,5 @@
 import PageStateGenerator, {
   IPageStateGeneratorAssertionBatch,
-  IPageStateSession,
 } from '@ulixee/hero-timetravel/lib/PageStateGenerator';
 import { Session as HeroSession, Tab } from '@ulixee/hero-core';
 import { fork } from 'child_process';
@@ -18,6 +17,9 @@ import { LoadStatus } from '@ulixee/hero-interfaces/Location';
 import PageStateCodeBlock from '@ulixee/hero-timetravel/lib/PageStateCodeBlock';
 import PageStateAssertions from '@ulixee/hero-timetravel/lib/PageStateAssertions';
 import DevtoolsPanelModule from './hero-plugin-modules/DevtoolsPanelModule';
+import IScriptInstanceMeta from '@ulixee/hero-interfaces/IScriptInstanceMeta';
+import PageStateSessionTimeline from './PageStateSessionTimeline';
+import SessionDb from '@ulixee/hero-core/dbs/SessionDb';
 
 const { log } = Log(module);
 
@@ -32,11 +34,9 @@ export default class PageStateManager extends TypedEventEmitter<{
     return this.pageStateById.get(this.activePageStateId)?.generator;
   }
 
-  public get activeTimelineBuilder(): TimelineBuilder {
-    return this.timelineBuildersByHeroSessionId.get(this.activeTimelineHeroSessionId);
+  public get activeSessionTimeline(): PageStateSessionTimeline {
+    return this.heroSessionTimelinesById.get(this.activeTimelineHeroSessionId);
   }
-
-  public defaultWaitMilliseconds = 5e3;
 
   private readonly pageStateById = new Map<
     string,
@@ -48,9 +48,8 @@ export default class PageStateManager extends TypedEventEmitter<{
     }
   >();
 
-  private readonly heroSessionsById = new Map<string, HeroSession>();
-  private readonly autoAssignedHeroSessionIds = new Set<string>();
-  private readonly timelineBuildersByHeroSessionId = new Map<string, TimelineBuilder>();
+  private readonly heroSessionTimelinesById = new Map<string, PageStateSessionTimeline>();
+  private readonly manuallyAssignedHeroSessionIds = new Set<string>();
 
   private activePageStateId: string;
   private isHeroSessionFocused = false;
@@ -61,14 +60,18 @@ export default class PageStateManager extends TypedEventEmitter<{
 
   private timetravelPlayer: TimetravelPlayer;
 
-  private readonly scriptEntrypoint: string;
+  private readonly scriptInstanceMeta: IScriptInstanceMeta;
+
+  // publishing debounce
+  private lastPublish: number;
+  private publishTimeout: NodeJS.Timeout;
 
   constructor(readonly sessionObserver: SessionObserver, timeline: TimelineBuilder) {
     super();
 
     bindFunctions(this);
     const sourceHeroSession = sessionObserver.heroSession;
-    this.scriptEntrypoint = sourceHeroSession.options.scriptInstanceMeta.entrypoint;
+    this.scriptInstanceMeta = sourceHeroSession.options.scriptInstanceMeta;
     this.logger = log.createChild(module, {
       sessionId: sourceHeroSession.id,
     });
@@ -91,11 +94,15 @@ export default class PageStateManager extends TypedEventEmitter<{
     // don't clear generators or sessions in case we re-open
     if (destroy) {
       this.pageStateById.clear();
-      this.heroSessionsById.clear();
+      for (const session of this.heroSessionTimelinesById.values()) {
+        session.close();
+      }
+      this.heroSessionTimelinesById.clear();
     }
 
     this.sessionObserver.tabGroupModule.off('tab-group-opened', this.listenForTabGroupOpened);
     await this.closeTimetravel();
+    this.tabGroupId = null;
 
     await this.sessionObserver.updateTabGroup(false);
   }
@@ -103,30 +110,37 @@ export default class PageStateManager extends TypedEventEmitter<{
   public addMultiverse(): void {
     const execArgv = ['--mode', 'multiverse'];
 
-    if (this.scriptEntrypoint.endsWith('.ts')) {
+    const { entrypoint, workingDirectory } = this.scriptInstanceMeta;
+    if (entrypoint.endsWith('.ts')) {
       execArgv.push('-r', 'ts-node/register');
     }
 
     try {
       this.placeholderSessions += 1;
-      fork(this.scriptEntrypoint, execArgv, {
+      fork(entrypoint, execArgv, {
+        cwd: workingDirectory,
         stdio: 'inherit',
         env: { ...process.env, HERO_CLI_NOPROMPT: 'true' },
       });
       if (this.activePageStateId) this.publish();
     } catch (error) {
+      this.placeholderSessions -= 1;
       this.logger.error('ERROR running multiverse', { error });
     }
   }
 
   public onMultiverseSession(heroSession: HeroSession) {
-    // might not be our session
-    if (heroSession.options.scriptInstanceMeta.entrypoint !== this.scriptEntrypoint) {
+    // not be our session
+    if (heroSession.options.scriptInstanceMeta.entrypoint !== this.scriptInstanceMeta.entrypoint) {
       return;
     }
     heroSession.configureHeaded({ showBrowser: false });
     heroSession.options.sessionKeepAlive = false;
     heroSession.options.sessionResume = null;
+
+    if (heroSession.mode === 'multiverse') {
+      heroSession.db.keepAlive = true;
+    }
     this.trackHeroSession(heroSession);
     this.placeholderSessions -= 1;
     if (this.activePageStateId) this.publish();
@@ -135,43 +149,44 @@ export default class PageStateManager extends TypedEventEmitter<{
   public async loadPageState(id: string): Promise<void> {
     this.emit('enter', { pageStateId: id });
     this.activePageStateId = id;
-    const unresolvedHeroSessionIds = this.getUnresolvedHeroSessionIds();
+
     const sessionIdToOpen =
-      unresolvedHeroSessionIds[0] ??
-      this.autoAssignedHeroSessionIds.values().next()?.value ??
-      this.heroSessionsById.keys().next().value;
+      this.generator.sessionsById.keys().next().value ?? this.getUnresolvedHeroSessionIds()[0];
     await this.openTimetravel(sessionIdToOpen);
-    await DevtoolsPanelModule.bySessionId
-      .get(sessionIdToOpen)
-      .closeDevtoolsPanelForPage(this.timetravelPlayer.activeTab.mirrorPage.page);
-    await this.timetravelPlayer.activeTab.mirrorPage.page.bringToFront();
+
+    this.sessionObserver
+      .groupTabs('', 'grey', true)
+      .then(x => {
+        this.tabGroupId = x;
+        this.sessionObserver.tabGroupModule.on('tab-group-opened', this.listenForTabGroupOpened);
+        return null;
+      })
+      .catch(console.error);
+
+    await this.closeDevtoolsPanel(sessionIdToOpen);
+
     this.publish();
   }
 
-  public async focusSessionTimeBoundary(isStartTime: boolean): Promise<void> {
-    const timelineBuilder = this.activeTimelineBuilder;
+  public async focusSessionLoadingTimeBoundary(isStartTime: boolean): Promise<void> {
     const focusedSessionId = this.activeTimelineHeroSessionId;
     const session = this.generator.sessionsById.get(focusedSessionId);
-    const percentOffset = timelineBuilder.commandTimeline.getTimelineOffsetForTimestamp(
-      isStartTime ? session.loadingRange[0] : session.loadingRange[1],
-    );
-    await this.timetravelPlayer.goto(percentOffset, timelineBuilder.lastMetadata);
+    await this.timetravelTo(isStartTime ? session.loadingRange[0] : session.loadingRange[1]);
   }
 
-  public async changeSessionTimeBoundary(
+  public async changeSessionLoadingTimeBoundary(
     percentOffset: number,
     isStartTime: boolean,
   ): Promise<void> {
-    this.autoAssignedHeroSessionIds.delete(this.activeTimelineHeroSessionId);
-    const timelineBuilder = this.activeTimelineBuilder;
-    const timestamp = timelineBuilder.commandTimeline.getTimestampForOffset(percentOffset);
-    await this.timetravelPlayer.goto(percentOffset, timelineBuilder.lastMetadata);
-    const focusedSessionId = this.activeTimelineHeroSessionId;
-    const session = this.generator.sessionsById.get(focusedSessionId);
+    this.manuallyAssignedHeroSessionIds.add(this.activeTimelineHeroSessionId);
+    const timestamp = this.activeSessionTimeline.changeLoadingRangeBoundary(
+      this.activePageStateId,
+      percentOffset,
+      isStartTime,
+    );
+    await this.timetravelTo(timestamp);
 
-    const index = isStartTime ? 0 : 1;
-    session.loadingRange[index] = timestamp;
-    session.needsResultsVerification = true;
+    const focusedSessionId = this.activeTimelineHeroSessionId;
     const modifiedState = this.generator.getStateForSessionId(focusedSessionId);
     if (modifiedState) {
       this.didMakeStateChanges(this.activePageStateId, modifiedState);
@@ -179,8 +194,18 @@ export default class PageStateManager extends TypedEventEmitter<{
     this.updateState();
   }
 
+  public extendSessionTime(sessionId: string, millis: number): Promise<void> {
+    this.manuallyAssignedHeroSessionIds.add(sessionId);
+
+    const sessionTimeline = this.heroSessionTimelinesById.get(sessionId);
+    sessionTimeline.extendTimelineRange(this.activePageStateId, millis);
+    // will update time in event from sessionTimeline
+
+    return Promise.resolve();
+  }
+
   public addState(name: string, ...heroSessionIds: string[]): void {
-    for (const id of heroSessionIds) this.autoAssignedHeroSessionIds.delete(id);
+    for (const id of heroSessionIds) this.manuallyAssignedHeroSessionIds.add(id);
     this.generator.addState(name, ...heroSessionIds);
     this.didMakeStateChanges(this.activePageStateId, name);
     this.updateState();
@@ -204,7 +229,7 @@ export default class PageStateManager extends TypedEventEmitter<{
   }
 
   public isShowingSession(heroSessionId: string): boolean {
-    return this.activeTimelineBuilder?.sessionId === heroSessionId;
+    return this.activeSessionTimeline?.sessionId === heroSessionId;
   }
 
   public unfocusSession(): void {
@@ -221,8 +246,6 @@ export default class PageStateManager extends TypedEventEmitter<{
       return;
     }
 
-    this.sessionObserver.tabGroupModule.off('tab-group-opened', this.close as any);
-
     if (this.timetravelPlayer) await this.closeTimetravel();
 
     this.activeTimelineHeroSessionId = heroSessionId;
@@ -233,9 +256,7 @@ export default class PageStateManager extends TypedEventEmitter<{
       this.sessionObserver.heroSession,
       this.generator.sessionsById.get(heroSessionId).timelineRange,
     );
-    this.tabGroupId = await this.sessionObserver.groupTabs('', 'grey', true);
-    this.sessionObserver.tabGroupModule.on('tab-group-opened', this.listenForTabGroupOpened);
-    this.activeTimelineBuilder.refreshMetadata();
+    this.activeSessionTimeline.refreshMetadata();
 
     await this.gotoActiveSessionEnd();
     this.timetravelPlayer.once('all-tabs-closed', this.onTimetravelTabsClosed);
@@ -255,10 +276,14 @@ export default class PageStateManager extends TypedEventEmitter<{
     }
   }
 
+  private async timetravelTo(timestamp: number): Promise<void> {
+    const offset = this.activeSessionTimeline.getTimelineOffset(timestamp);
+    await this.timetravelPlayer.goto(offset, this.activeSessionTimeline.lastMetadata);
+  }
+
   private async gotoActiveSessionEnd(): Promise<void> {
     const sessionDetails = this.generator.sessionsById.get(this.activeTimelineHeroSessionId);
-    const offsets = this.getTimelineOffsets(sessionDetails);
-    await this.timetravelPlayer.goto(offsets[1], this.activeTimelineBuilder.lastMetadata);
+    await this.timetravelTo(sessionDetails.loadingRange[1]);
   }
 
   private async onTimetravelTabsClosed(): Promise<void> {
@@ -277,74 +302,31 @@ export default class PageStateManager extends TypedEventEmitter<{
     await closePromise;
   }
 
-  private getTimelineOffsets(pageStateSession: IPageStateSession): [number, number] {
-    const timelineBuilder = this.timelineBuildersByHeroSessionId.get(
-      pageStateSession.sessionId,
-    ).commandTimeline;
-    const [loadStart, loadEnd] = pageStateSession.loadingRange;
-    const offsetLeft = timelineBuilder.getTimelineOffsetForTimestamp(loadStart);
-    const offsetRight = timelineBuilder.getTimelineOffsetForTimestamp(loadEnd);
-    return [offsetLeft, offsetRight];
-  }
-
   private trackHeroSession(heroSession: HeroSession, timeline?: TimelineBuilder): void {
-    const id = heroSession.id;
-    this.heroSessionsById.set(id, heroSession);
+    const pageStateSessionTimeline = this.trackPageStateTimeline(heroSession.db, timeline);
+    pageStateSessionTimeline.trackSession(heroSession);
     heroSession.on('tab-created', this.onTab);
+  }
 
-    if (heroSession.mode === 'multiverse') {
-      heroSession.db.keepAlive = true;
+  private trackPageStateTimeline(
+    db: SessionDb,
+    timeline?: TimelineBuilder,
+  ): PageStateSessionTimeline {
+    const pageStateSessionTimeline = new PageStateSessionTimeline(db, this.pageStateById, timeline);
+    pageStateSessionTimeline.on('updated-generator', this.updateStateForGenerator);
+    pageStateSessionTimeline.on('timeline-change', this.onTimelineChange.bind(this, db.sessionId));
+    pageStateSessionTimeline.timelineBuilder.on('updated', this.publish);
+    this.heroSessionTimelinesById.set(db.sessionId, pageStateSessionTimeline);
+    return pageStateSessionTimeline;
+  }
+
+  private onTimelineChange(
+    heroSessionId: string,
+    event: { timelineRange: [number, number] },
+  ): void {
+    if (this.timetravelPlayer?.sessionId === heroSessionId) {
+      this.timetravelPlayer.refreshTicks(event.timelineRange).catch(console.error);
     }
-
-    timeline ??= new TimelineBuilder(heroSession.db, heroSession);
-    timeline.on('updated', this.onTimelineUpdated.bind(this, timeline, heroSession.id));
-    this.timelineBuildersByHeroSessionId.set(id, timeline);
-    this.onTimelineUpdated(timeline, heroSession.id);
-  }
-
-  private onTimelineUpdated(timelineBuilder: TimelineBuilder, sessionId: string) {
-    timelineBuilder.refreshMetadata();
-    const generatorSession = this.generator?.sessionsById?.get(sessionId);
-    if (generatorSession && this.autoAssignedHeroSessionIds.has(sessionId)) {
-      let hasChanges = false;
-      for (const url of timelineBuilder.lastMetadata?.urls ?? []) {
-        for (const loadEvent of url.loadStatusOffsets) {
-          if (loadEvent.offsetPercent === -1) continue;
-          if (loadEvent.loadStatus === LoadStatus.HttpResponded) {
-            if (loadEvent.timestamp > generatorSession.loadingRange[0]) {
-              generatorSession.loadingRange[0] = loadEvent.timestamp;
-              hasChanges = true;
-            }
-          }
-          if (loadEvent.loadStatus === LoadStatus.DomContentLoaded) {
-            if (
-              // before complete
-              loadEvent.timestamp < generatorSession.timelineRange[1] &&
-              // after load event
-              loadEvent.timestamp > generatorSession.loadingRange[0]
-            ) {
-              generatorSession.loadingRange[1] = loadEvent.timestamp;
-              hasChanges = true;
-            }
-          }
-        }
-      }
-      if (hasChanges) this.updateState();
-    }
-    this.publish();
-  }
-
-  private publish(): void {
-    this.emit('updated', this.toEvent());
-  }
-
-  private updateState(generator?: PageStateGenerator): void {
-    generator ??= this.generator;
-    if (!generator) return;
-    generator
-      .evaluate()
-      .then(() => this.publish())
-      .catch(error => this.logger.error('Error updating page state', { error }));
   }
 
   private onTab(event: { tab: Tab }) {
@@ -361,29 +343,15 @@ export default class PageStateManager extends TypedEventEmitter<{
       this.bindPageStateListenerToGenerator(listener);
     }
 
+    listener.on('resolved', this.onPageStateResolved.bind(this, tab, pageStateId));
+
+    const sessionTimeline = this.heroSessionTimelinesById.get(tab.sessionId);
+
+    const loadingRange = sessionTimeline.getNewPageStateLoadingRange(tab, listener);
     const generator = this.pageStateById.get(pageStateId).generator;
+    generator.addSession(tab.session.db, tab.id, loadingRange);
+    sessionTimeline.onNewPageState(tab, listener);
 
-    if (listener.states.length) {
-      listener.on('resolved', this.onPageStateResolved.bind(this, tab, pageStateId));
-    }
-
-    const startTime = listener.startTime;
-    const endTime = startTime + this.defaultWaitMilliseconds;
-    const timeRange: [number, number] = [startTime, endTime];
-
-    generator.addSession(tab.session.db, tab.id, timeRange, timeRange);
-    this.autoAssignedHeroSessionIds.add(tab.sessionId);
-
-    const timelineBuilder = this.timelineBuildersByHeroSessionId.get(tab.sessionId);
-    timelineBuilder?.setTimeRange(...timeRange);
-    if (timelineBuilder && endTime > Date.now()) {
-      timelineBuilder.recordScreenUntilTime = endTime;
-    }
-    if (this.timetravelPlayer && this.activeTimelineHeroSessionId === tab.sessionId) {
-      this.timetravelPlayer.refreshTicks(timeRange).catch(error => {
-        this.logger.error('Error refreshing Timetravel ticks', { error });
-      });
-    }
     this.updateState(generator);
   }
 
@@ -401,6 +369,33 @@ export default class PageStateManager extends TypedEventEmitter<{
     this.updateState(generator);
   }
 
+  private publish(): void {
+    const now = Date.now();
+    const lastPublish = this.lastPublish ?? now - 201;
+    const millisSincePublish = now - lastPublish;
+    if (millisSincePublish < 200) {
+      this.publishTimeout = setTimeout(this.publish, 200 - millisSincePublish);
+      return;
+    }
+    clearTimeout(this.publishTimeout);
+    this.lastPublish = now;
+    this.emit('updated', this.toEvent());
+  }
+
+  private updateStateForGenerator(event: { pageStateId: string }): void {
+    const pageState = this.pageStateById.get(event.pageStateId);
+    this.updateState(pageState.generator);
+  }
+
+  private updateState(generator?: PageStateGenerator): void {
+    generator ??= this.generator;
+    if (!generator) return;
+    generator
+      .evaluate()
+      .then(() => this.publish())
+      .catch(error => this.logger.error('Error updating page state', { error }));
+  }
+
   private recordPageState(tab: Tab, listener: PageStateListener): void {
     const pageStateId = listener.id;
     const generator = new PageStateGenerator(pageStateId);
@@ -408,6 +403,12 @@ export default class PageStateManager extends TypedEventEmitter<{
     for (const [id, rawAssertionsData] of listener.rawBatchAssertionsById) {
       if (id.startsWith('@')) {
         generator.import(rawAssertionsData as IPageStateGeneratorAssertionBatch);
+        for (const [sessionId, session] of generator.sessionsById) {
+          this.manuallyAssignedHeroSessionIds.add(sessionId);
+          if (session.db) {
+            this.trackPageStateTimeline(session.db, new TimelineBuilder(session.db, session.timelineRange));
+          }
+        }
       }
     }
 
@@ -461,9 +462,17 @@ export default class PageStateManager extends TypedEventEmitter<{
     }
   }
 
+  private async closeDevtoolsPanel(sessionId: string) {
+    // close
+    await DevtoolsPanelModule.bySessionId
+      .get(sessionId)
+      .closeDevtoolsPanelForPage(this.timetravelPlayer.activeTab.mirrorPage.page);
+    await this.timetravelPlayer.activeTab.mirrorPage.page.bringToFront();
+  }
+
   private getUnresolvedHeroSessionIds(pageStateId?: string): string[] {
     const generator = this.pageStateById.get(pageStateId ?? this.activePageStateId).generator;
-    const unassignedSessionIds = new Set(this.heroSessionsById.keys());
+    const unassignedSessionIds = new Set(this.heroSessionTimelinesById.keys());
     for (const details of generator.statesByName.values()) {
       for (const sessionId of details.sessionIds) unassignedSessionIds.delete(sessionId);
     }
@@ -471,7 +480,7 @@ export default class PageStateManager extends TypedEventEmitter<{
   }
 
   private toEvent(): IPageStateUpdateEvent {
-    if (!this.activePageStateId) return;
+    if (!this.activePageStateId) return null;
     const { needsCodeChange } = this.pageStateById.get(this.activePageStateId);
 
     const result: IPageStateUpdateEvent = {
@@ -496,11 +505,13 @@ export default class PageStateManager extends TypedEventEmitter<{
     }
 
     for (const [id, generatorSession] of generator.sessionsById) {
-      const timeline = CommandTimeline.fromDb(generatorSession.db, generatorSession.timelineRange);
-      const data = TimelineBuilder.createTimelineMetadata(timeline, generatorSession.db);
+      const sessionTimeline = this.heroSessionTimelinesById.get(id);
+      const data = sessionTimeline.refreshMetadata();
       const assertionCounts = generator.sessionAssertions.sessionAssertionsCount(id);
 
-      const timelineOffsetPercents = this.getTimelineOffsets(generatorSession);
+      const timelineOffsetPercents = sessionTimeline.getTimelineOffsets(
+        generatorSession.loadingRange,
+      );
       result.heroSessions.push({
         id,
         timelineRange: generatorSession.timelineRange,
@@ -514,15 +525,19 @@ export default class PageStateManager extends TypedEventEmitter<{
     for (const id of result.unresolvedHeroSessionIds) {
       // if created, but not in generator yet, add now
       if (!generator.sessionsById.has(id)) {
-        const db = this.heroSessionsById.get(id)?.db;
+        const heroSession = this.heroSessionTimelinesById.get(id).heroSession;
+        const db = heroSession?.db;
         if (!db) continue;
 
         const navigations = db.frameNavigations.getAllNavigations();
-        let startTime = db.commands.all()[0]?.runStartDate ?? Date.now();
-        if (navigations.length)
-          startTime = navigations
-            .map(x => x.statusChanges.get(LoadStatus.DomContentLoaded))
-            .find(x => x);
+        let startTime = heroSession.createdTime;
+        for (const nav of navigations) {
+          const domContentLoaded = nav.statusChanges.get(LoadStatus.DomContentLoaded);
+          if (domContentLoaded) {
+            startTime = domContentLoaded;
+            break;
+          }
+        }
         const timelineRange: [number, number] = [startTime, Date.now()];
         const timeline = CommandTimeline.fromDb(db, timelineRange);
         const data = TimelineBuilder.createTimelineMetadata(timeline, db);

--- a/apps/chromealive-core/lib/PageStateSessionTimeline.ts
+++ b/apps/chromealive-core/lib/PageStateSessionTimeline.ts
@@ -1,0 +1,223 @@
+import TimelineBuilder from '@ulixee/hero-timetravel/player/TimelineBuilder';
+import { Session as HeroSession, Tab } from '@ulixee/hero-core';
+import { IFrameNavigationEvents } from '@ulixee/hero-core/lib/FrameNavigations';
+import { LoadStatus } from '@ulixee/hero-interfaces/Location';
+import ITimelineMetadata from '@ulixee/hero-interfaces/ITimelineMetadata';
+import PageStateGenerator, {
+  IPageStateSession,
+} from '@ulixee/hero-timetravel/lib/PageStateGenerator';
+import SessionDb from '@ulixee/hero-core/dbs/SessionDb';
+import PageStateListener, { IPageStateEvents } from '@ulixee/hero-core/lib/PageStateListener';
+import { TypedEventEmitter } from '@ulixee/commons/lib/eventUtils';
+
+export default class PageStateSessionTimeline extends TypedEventEmitter<{
+  'updated-generator': { pageStateId: string };
+  'timeline-change': { pageStateId: string; timelineRange: [number, number] };
+}> {
+  public defaultWaitMilliseconds = 5e3;
+
+  public get lastMetadata(): ITimelineMetadata {
+    return this.timelineBuilder.lastMetadata;
+  }
+
+  public get sessionId(): string {
+    return this.db.sessionId;
+  }
+
+  public heroSession?: HeroSession;
+
+  constructor(
+    readonly db: SessionDb,
+    private readonly generatorsByPageStateId: Map<string, { generator: PageStateGenerator }>,
+    public readonly timelineBuilder?: TimelineBuilder,
+  ) {
+    super();
+    this.timelineBuilder ??= new TimelineBuilder(db);
+  }
+
+  public trackSession(heroSession: HeroSession): void {
+    this.heroSession = heroSession;
+    this.timelineBuilder.trackLiveSession(heroSession);
+  }
+
+  public changeLoadingRangeBoundary(
+    pageStateId: string,
+    offsetPercent: number,
+    isStartTime: boolean,
+  ): number {
+    console.log(
+      'changing loading range',
+      offsetPercent,
+      this.timelineBuilder.commandTimeline.getTimestampForOffset(offsetPercent),
+      this.timelineBuilder.timelineRange,
+    );
+    const timestamp = this.getTimestampForOffset(offsetPercent);
+    const generatorSession = this.getGeneratorSession(pageStateId);
+
+    const index = isStartTime ? 0 : 1;
+    generatorSession.loadingRange[index] = timestamp;
+    generatorSession.needsProcessing = true;
+    return timestamp;
+  }
+
+  public extendTimelineRange(pageStateId: string, millis: number): [number, number] {
+    const timelineRange = this.timelineBuilder.timelineRange;
+
+    const endTime = timelineRange[1] + millis;
+    const timeRange: [number, number] = [timelineRange[0], endTime];
+    this.changeTimelineRange(pageStateId, timeRange);
+    return timeRange;
+  }
+
+  public onNewPageState(tab: Tab, listener: PageStateListener): void {
+    const pageStateId = listener.id;
+    const statusChangeCb = this.onTabNavigationStatusChange.bind(this, tab, pageStateId);
+    tab.navigations.on('status-change', statusChangeCb);
+    listener.on('resolved', this.onPageStateResolved.bind(this, tab, statusChangeCb));
+    this.timelineBuilder.recordScreenUntilLoad = true;
+
+    const generatorSession = this.getGeneratorSession(pageStateId);
+    let endTime = generatorSession.loadingRange[1];
+
+    const lastNav = tab.navigations.getLastLoadedNavigation();
+    const loaded = lastNav.statusChanges.get(LoadStatus.AllContentLoaded);
+    if (loaded > endTime) {
+      endTime = loaded;
+    }
+
+    this.changeTimelineRange(pageStateId, [listener.startTime, endTime]);
+  }
+
+  public getNewPageStateLoadingRange(tab: Tab, listener: PageStateListener): [number, number] {
+    const pageStateId = listener.id;
+    const timelineMillis = this.getDefaultTimelineMillis(pageStateId, tab.sessionId);
+    let startTime = listener.startTime;
+    let endTime = startTime + timelineMillis;
+
+    const firstNav = tab.navigations.history
+      .find(x => x.statusChanges.get(LoadStatus.HttpRequested) > startTime)
+      ?.statusChanges?.get(LoadStatus.HttpRequested);
+    if (firstNav && firstNav > startTime) startTime = firstNav;
+
+    const lastNav = tab.navigations.getLastLoadedNavigation();
+    const domContentLoaded = lastNav.statusChanges.get(LoadStatus.DomContentLoaded);
+    if (domContentLoaded > endTime) {
+      endTime = domContentLoaded;
+    }
+
+    return [startTime, endTime];
+  }
+
+  public close(): void {
+    if (!this.heroSession) TimelineBuilder.bySessionId.delete(this.sessionId);
+  }
+
+  public getTimestampForOffset(offset: number): number {
+    return this.timelineBuilder.commandTimeline.getTimestampForOffset(offset);
+  }
+
+  public getTimelineOffset(timestamp: number): number {
+    return this.timelineBuilder.commandTimeline.getTimelineOffsetForTimestamp(timestamp);
+  }
+
+  public getTimelineOffsets(timeRange: [number, number]): [number, number] {
+    const [loadStart, loadEnd] = timeRange;
+    return [this.getTimelineOffset(loadStart), this.getTimelineOffset(loadEnd)];
+  }
+
+  public refreshMetadata(): ITimelineMetadata {
+    return this.timelineBuilder.refreshMetadata();
+  }
+
+  private getGeneratorSession(pageStateId: string): IPageStateSession {
+    return this.generatorsByPageStateId
+      .get(pageStateId)
+      ?.generator?.sessionsById?.get(this.sessionId);
+  }
+
+  private onPageStateResolved(
+    tab: Tab,
+    statusChangeListener: (ev: IFrameNavigationEvents['status-change']) => void,
+    resolution: IPageStateEvents['resolved'],
+  ) {
+    // keep going if we run into an error?
+    if (resolution.error) return;
+    tab.navigations.off('status-change', statusChangeListener);
+    this.timelineBuilder.recordScreenUntilLoad = false;
+  }
+
+  private changeTimelineRange(pageStateId: string, timeRange: [number, number]) {
+    const generatorSession = this.getGeneratorSession(pageStateId);
+    if (generatorSession.timelineRange?.toString() === timeRange.toString()) return;
+
+    generatorSession.timelineRange = [...timeRange];
+    generatorSession.needsProcessing = true;
+    this.timelineBuilder.timelineRange = [...timeRange];
+
+    const endTime = timeRange[1];
+    if (endTime > Date.now()) {
+      this.timelineBuilder.recordScreenUntilTime = endTime;
+    }
+    this.emit('timeline-change', {
+      pageStateId,
+      timelineRange: [...timeRange],
+    });
+  }
+
+  private onTabNavigationStatusChange(
+    tab: Tab,
+    pageStateId: string,
+    event: IFrameNavigationEvents['status-change'],
+  ): void {
+    const generatorSession = this.getGeneratorSession(pageStateId);
+    const { loadingRange, timelineRange } = generatorSession;
+    const loadStatus = event.newStatus;
+    const timestamp = event.statusChanges[event.newStatus];
+
+    let hasLoadingRangeChanges = false;
+    if (loadStatus === LoadStatus.HttpResponded && timestamp > loadingRange[0]) {
+      loadingRange[0] = timestamp;
+      hasLoadingRangeChanges = true;
+    }
+
+    if (
+      loadStatus === LoadStatus.DomContentLoaded &&
+      // after loadingRange start
+      timestamp > loadingRange[0] &&
+      timestamp !== loadingRange[1]
+    ) {
+      loadingRange[1] = timestamp;
+      hasLoadingRangeChanges = true;
+    }
+    if (hasLoadingRangeChanges) {
+      generatorSession.needsProcessing = true;
+      this.emit('updated-generator', { pageStateId });
+    }
+
+    // don't update for Dom Content Loaded past range
+    if (loadStatus === LoadStatus.DomContentLoaded && timestamp < timelineRange[1]) {
+      return;
+    }
+
+    if (
+      loadStatus === LoadStatus.AllContentLoaded ||
+      loadStatus === LoadStatus.DomContentLoaded ||
+      loadStatus === LoadStatus.PaintingStable
+    ) {
+      this.changeTimelineRange(pageStateId, [timelineRange[0], timestamp + 500]);
+    }
+  }
+
+  private getDefaultTimelineMillis(pageStateId: string, excludeSessionId: string): number {
+    const generator = this.generatorsByPageStateId.get(pageStateId).generator;
+    for (const [id, session] of generator.sessionsById) {
+      if (id !== excludeSessionId) {
+        const timelineMillis = session.timelineRange[1] - session.timelineRange[0];
+        if (timelineMillis > this.defaultWaitMilliseconds) {
+          return timelineMillis;
+        }
+      }
+    }
+    return this.defaultWaitMilliseconds;
+  }
+}

--- a/apps/chromealive-core/lib/SessionObserver.ts
+++ b/apps/chromealive-core/lib/SessionObserver.ts
@@ -18,6 +18,7 @@ import PageStateManager from './PageStateManager';
 import TabGroupModule from './hero-plugin-modules/TabGroupModule';
 import TimetravelPlayer from '@ulixee/hero-timetravel/player/TimetravelPlayer';
 import ChromeAliveCore from '../index';
+import TimelineRecorder from '@ulixee/hero-timetravel/player/TimelineRecorder';
 
 const { log } = Log(module);
 
@@ -38,6 +39,7 @@ export default class SessionObserver extends TypedEventEmitter<{
     startingCommandId: number;
     timestamp: number;
     isUnresolved: boolean;
+    resolvedState: string;
   }[] = [];
 
   private scriptLastModifiedTime: number;
@@ -46,6 +48,8 @@ export default class SessionObserver extends TypedEventEmitter<{
   private outputRebuilder = new OutputRebuilder();
   private databoxInput: any = null;
   private databoxInputBytes = 0;
+  private readonly timelineRecorder: TimelineRecorder;
+  private hasScriptUpdatesSinceLastRun = false;
 
   constructor(public readonly heroSession: HeroSession) {
     super();
@@ -59,9 +63,10 @@ export default class SessionObserver extends TypedEventEmitter<{
     this.heroSession.on('closing', this.close);
     this.heroSession.once('closed', () => this.emit('closed'));
 
-    this.timelineBuilder = new TimelineBuilder(heroSession.db);
-    this.timelineBuilder.trackLiveSession(heroSession);
-    this.timelineBuilder.on('updated', () => this.emit('hero:updated'));
+    this.timelineBuilder = new TimelineBuilder({ liveSession: heroSession });
+
+    this.timelineRecorder = new TimelineRecorder(heroSession);
+    this.timelineRecorder.on('updated', () => this.emit('hero:updated'));
 
     this.timetravelPlayer = TimetravelPlayer.create(heroSession.id, heroSession);
     this.timetravelPlayer.on('all-tabs-closed', this.onTimetravelClosed);
@@ -70,7 +75,7 @@ export default class SessionObserver extends TypedEventEmitter<{
 
     this.scriptLastModifiedTime = Fs.statSync(this.scriptInstanceMeta.entrypoint).mtimeMs;
 
-    this.pageStateManager = new PageStateManager(this, this.timelineBuilder);
+    this.pageStateManager = new PageStateManager(this);
     this.pageStateManager.on('enter', () =>
       ChromeAliveCore.sendAppEvent('App.mode', 'pagestate-generator'),
     );
@@ -84,6 +89,11 @@ export default class SessionObserver extends TypedEventEmitter<{
       },
       this.onFileUpdated,
     );
+  }
+
+  public getTimelineBuilder(heroSessionId: string): TimelineBuilder {
+    if (heroSessionId === this.heroSession.id) return this.timelineBuilder;
+    return this.pageStateManager.getHeroSessionTimeline(heroSessionId)?.timelineBuilder;
   }
 
   public onMultiverseSession(session: HeroSession): void {
@@ -125,6 +135,10 @@ export default class SessionObserver extends TypedEventEmitter<{
   public close(): void {
     Fs.unwatchFile(this.scriptInstanceMeta.entrypoint, this.onFileUpdated);
     this.heroSession.off('tab-created', this.onTabCreated);
+    this.heroSession.off('kept-alive', this.onHeroSessionKeptAlive);
+    this.heroSession.off('resumed', this.onHeroSessionResumed);
+    this.heroSession.off('closing', this.close);
+    this.timelineRecorder.stop();
     this.timetravelPlayer?.close();
     this.pageStateManager.close(true).catch(console.error);
   }
@@ -134,16 +148,26 @@ export default class SessionObserver extends TypedEventEmitter<{
     const timeline = this.timelineBuilder.refreshMetadata();
     const commandTimeline = this.timelineBuilder.commandTimeline;
 
+    let needsPageStateResolutionId: string = null;
     for (const state of this.waitForPageStateEvents) {
-      let offsetPercent = commandTimeline.getTimelineOffsetForTimestamp(state.timestamp);
+      const offsetPercent = commandTimeline.getTimelineOffsetForTimestamp(state.timestamp);
       if (offsetPercent === -1) continue;
-      if (state.isUnresolved === true) offsetPercent = 100;
 
       pageStates.push({
         id: state.id,
         offsetPercent,
         isUnresolved: state.isUnresolved,
+        resolvedState: state.resolvedState,
       });
+    }
+    const lastPageState = pageStates[pageStates.length - 1];
+    if (lastPageState) {
+      if (lastPageState.isUnresolved === true) {
+        if (!this.hasScriptUpdatesSinceLastRun) {
+          needsPageStateResolutionId = lastPageState.id;
+        }
+        lastPageState.offsetPercent = 100;
+      }
     }
 
     const currentTab = this.heroSession.getLastActiveTab();
@@ -164,8 +188,7 @@ export default class SessionObserver extends TypedEventEmitter<{
       heroSessionId: this.heroSession.id,
       runtimeMs: commandTimeline.runtimeMs,
       playbackState: this.playbackState,
-      needsPageStateResolution:
-        pageStates.length && pageStates[pageStates.length - 1].isUnresolved === true,
+      needsPageStateResolutionId,
       pageStates,
       timeline,
     };
@@ -233,15 +256,16 @@ export default class SessionObserver extends TypedEventEmitter<{
   public async onTimetravelOpened(): Promise<void> {
     this.playbackState = 'timetravel';
     this.tabGroupModule.once('tab-group-opened', this.closeTimetravel);
-    await this.updateTabGroup(true);
+    await this.updateTabGroup(true).catch(console.error);
     this.timetravelPlayer.once('timetravel-to-end', this.closeTimetravel);
+    this.emit('hero:updated');
   }
 
   private async onTimetravelClosed(): Promise<void> {
     this.playbackState = 'paused';
     this.tabGroupModule.off('tab-group-opened', this.closeTimetravel);
-    await this.updateTabGroup(false);
     this.timetravelPlayer.off('timetravel-to-end', this.closeTimetravel);
+    await this.updateTabGroup(false).catch(console.error);
     this.emit('hero:updated');
   }
 
@@ -254,12 +278,16 @@ export default class SessionObserver extends TypedEventEmitter<{
 
   private onFileUpdated(stats: Fs.Stats): void {
     this.scriptLastModifiedTime = stats.mtimeMs;
+    this.hasScriptUpdatesSinceLastRun = true;
     this.emit('hero:updated');
   }
 
   private onHeroSessionResumed(): void {
     this.playbackState = 'live';
     this.bindDatabox();
+    this.hasScriptUpdatesSinceLastRun = false;
+    this.waitForPageStateEvents.length = 0;
+    this.pageStateManager.clear();
     this.emit('hero:updated');
     this.emit('databox:updated');
   }
@@ -296,21 +324,19 @@ export default class SessionObserver extends TypedEventEmitter<{
   private onTabCreated(tabEvent: { tab: Tab }) {
     const tab = tabEvent.tab;
     tab.on('wait-for-pagestate', this.onWaitForPageState);
-
-    // don't start screencast if we're just poking around
-    if (this.playbackState === 'paused') return;
   }
 
   private onWaitForPageState(event: ITabEventParams['wait-for-pagestate']): void {
     const { listener } = event;
-
     const id = listener.id;
     const startingCommandId = listener.startingCommandId;
     const timestamp = listener.commandStartTime;
-    const pageState = { id, startingCommandId, timestamp, isUnresolved: null };
+    const pageState = { id, startingCommandId, timestamp, isUnresolved: null, resolvedState: null };
     this.waitForPageStateEvents.push(pageState);
+    this.emit('hero:updated');
     listener.on('resolved', state => {
-      if (!state.state) pageState.isUnresolved = true;
+      pageState.isUnresolved = !state.state;
+      pageState.resolvedState = state.state;
       this.emit('hero:updated');
     });
   }

--- a/apps/chromealive-core/lib/SessionObserver.ts
+++ b/apps/chromealive-core/lib/SessionObserver.ts
@@ -59,7 +59,8 @@ export default class SessionObserver extends TypedEventEmitter<{
     this.heroSession.on('closing', this.close);
     this.heroSession.once('closed', () => this.emit('closed'));
 
-    this.timelineBuilder = new TimelineBuilder(heroSession.db, heroSession);
+    this.timelineBuilder = new TimelineBuilder(heroSession.db);
+    this.timelineBuilder.trackLiveSession(heroSession);
     this.timelineBuilder.on('updated', () => this.emit('hero:updated'));
 
     this.timetravelPlayer = TimetravelPlayer.create(heroSession.id, heroSession);
@@ -111,6 +112,7 @@ export default class SessionObserver extends TypedEventEmitter<{
       this.logger.info('Resuming session', { execArgv });
       fork(script, execArgv, {
         // execArgv,
+        cwd: this.scriptInstanceMeta.workingDirectory,
         stdio: 'inherit',
         env: { ...process.env, HERO_CLI_NOPROMPT: 'true' },
       });

--- a/apps/chromealive-core/lib/hero-plugin-modules/WindowBoundsModule.ts
+++ b/apps/chromealive-core/lib/hero-plugin-modules/WindowBoundsModule.ts
@@ -45,6 +45,7 @@ export default class WindowBoundsModule {
           bounds as IBounds,
         );
         const maxBounds = AliveBarPositioner.getMaxChromeBounds();
+        if (!maxBounds) return;
         if (maxBounds.height === bounds.height && maxBounds.width === bounds.width) return;
 
         return page.devtoolsSession.send('Browser.setWindowBounds', {

--- a/apps/chromealive-core/package.json
+++ b/apps/chromealive-core/package.json
@@ -16,7 +16,7 @@
     "@ulixee/apps-chromealive": "1.5.4",
     "@ulixee/apps-chromealive-interfaces": "1.5.4",
     "@types/chrome": "^0.0.154",
-    "nanoid": "^3.1.29"
+    "nanoid": "^3.1.30"
   },
   "peerDependencies": {
     "@ulixee/databox-core": "^1.5.4",

--- a/apps/chromealive-extension/package.json
+++ b/apps/chromealive-extension/package.json
@@ -21,7 +21,7 @@
     "core-js": "^3.6.5",
     "css-selector-generator": "^3.4.4",
     "css-selector-tools": "^1.0.9",
-    "nanoid": "^3.1.29",
+    "nanoid": "^3.1.30",
     "vue": "^3.0.0"
   },
   "devDependencies": {

--- a/apps/chromealive-extension/src/lib/background/BackgroundMessenger.ts
+++ b/apps/chromealive-extension/src/lib/background/BackgroundMessenger.ts
@@ -228,7 +228,7 @@ function connectToTabContentScript(
 ): chrome.runtime.Port {
   let port = findPort(tabId, portLocation);
   if (port) return port;
-  if (portLocation !== MessageLocation.ContentScript) return;
+  if (portLocation !== MessageLocation.ContentScript && !sendThroughContentScript.includes(portLocation)) return;
   try {
     port = chrome.tabs.connect(tabId, { name: currentMessengerLocation, frameId: 0 });
     registerPort(tabId, portLocation, port);

--- a/apps/chromealive-extension/src/lib/background/BackgroundMessenger.ts
+++ b/apps/chromealive-extension/src/lib/background/BackgroundMessenger.ts
@@ -95,7 +95,7 @@ chrome.runtime.onConnect.addListener(port => {
       if (tabId) unregisterPort(tabId, portLocation);
     });
     if (portLocation === MessageLocation.ContentScript) {
-      if(!port.sender.tab) {
+      if (!port.sender.tab) {
         logDebug('MISSING tab: ', port.sender);
       }
       const message: IMessageObject = {
@@ -113,6 +113,13 @@ chrome.runtime.onConnect.addListener(port => {
   } catch (e) {
     logDebug('ERROR: ', e);
     // nothing to do here
+  }
+});
+
+chrome.runtime.onSuspend.addListener(() => {
+  for (const port of Object.values(portsByTabId)) {
+    port.devtoolsVue?.disconnect();
+    port.contentScript?.disconnect();
   }
 });
 
@@ -173,11 +180,7 @@ async function routeInternally(
   }
 }
 
-function routeInternallyToTab(
-  tabId: number,
-  message: IMessageObject,
-  isRetry = false,
-): boolean {
+function routeInternallyToTab(tabId: number, message: IMessageObject, isRetry = false): boolean {
   try {
     const port = connectToTabContentScript(tabId, message.destLocation);
     if (port) {
@@ -206,9 +209,15 @@ function unregisterPort(tabId: number, portLocation: IMessageLocation) {
   }
 }
 
-const sendThroughContentScript: IMessageLocation[] = [MessageLocation.ContentScript, MessageLocation.Core, MessageLocation.DevtoolsPrivate ];
+const sendThroughContentScript: IMessageLocation[] = [
+  MessageLocation.ContentScript,
+  MessageLocation.Core,
+  MessageLocation.DevtoolsPrivate,
+];
 function findPort(tabId: number, portLocation: IMessageLocation) {
-  const nextPortLocation = sendThroughContentScript.includes(portLocation) ? MessageLocation.ContentScript : portLocation;
+  const nextPortLocation = sendThroughContentScript.includes(portLocation)
+    ? MessageLocation.ContentScript
+    : portLocation;
   if (!portsByTabId[tabId]) return;
   return portsByTabId[tabId][nextPortLocation];
 }

--- a/apps/chromealive-interfaces/apis/IPageStateApi.ts
+++ b/apps/chromealive-interfaces/apis/IPageStateApi.ts
@@ -13,6 +13,7 @@ export default interface IPageStateApi {
     isStartTime: boolean;
   }): Promise<void>;
   focusSessionTime(args: { heroSessionId: string; isStartTime: boolean }): Promise<void>;
+  extendSessionTime(args: { heroSessionId: string; addMillis: number }): Promise<void>;
   save(): Promise<{
     needsCodeChange: boolean;
     code: string;

--- a/apps/chromealive-interfaces/apis/index.ts
+++ b/apps/chromealive-interfaces/apis/index.ts
@@ -22,6 +22,7 @@ export type IApiHandlerSpec = {
   'PageState.openSession': PageStateApi['openSession'];
   'PageState.modifySessionTimes': PageStateApi['modifySessionTimes'];
   'PageState.focusSessionTime': PageStateApi['focusSessionTime'];
+  'PageState.extendSessionTime': PageStateApi['extendSessionTime'];
   'PageState.save': PageStateApi['save'];
   'PageState.exit': PageStateApi['exit'];
 };

--- a/apps/chromealive-interfaces/events/IHeroSessionActiveEvent.ts
+++ b/apps/chromealive-interfaces/events/IHeroSessionActiveEvent.ts
@@ -8,11 +8,12 @@ export default interface IHeroSessionActiveEvent {
   playbackState: 'live' | 'paused' | 'timetravel';
   run: number;
   runtimeMs: number;
-  needsPageStateResolution: boolean;
+  needsPageStateResolutionId: string;
   pageStates: {
     id: string;
     offsetPercent: number;
     isUnresolved: boolean;
+    resolvedState: string;
   }[];
   timeline: ITimelineMetadata;
 }

--- a/apps/chromealive-ui/src/pages/app/views/PageStateGenerator.vue
+++ b/apps/chromealive-ui/src/pages/app/views/PageStateGenerator.vue
@@ -416,6 +416,7 @@ export default Vue.defineComponent({
             break;
           }
         }
+        this.focusedTimelineHandle = 'end';
         this.timelineOffsetLeft = focusedSession.timelineOffsetPercents[0];
         this.timelineOffsetRight = focusedSession.timelineOffsetPercents[1];
         this.showTimelineHover = false;
@@ -511,7 +512,6 @@ export default Vue.defineComponent({
     timelineHandleDragend(): void {
       if (!this.isDraggingTimelineHandle) return;
       this.isDraggingTimelineHandle = false;
-      this.focusedTimelineHandle = null;
       this.updateSessionTimes().catch(console.error);
     },
 

--- a/apps/chromealive-ui/src/pages/pagestate-panel/index.vue
+++ b/apps/chromealive-ui/src/pages/pagestate-panel/index.vue
@@ -66,6 +66,7 @@ export default Vue.defineComponent({
     let sessionsByState = Vue.reactive<Record<string, IPageStateUpdatedEvent['heroSessions']>>({});
 
     function onPageStateUpdated(data: IPageStateUpdatedEvent) {
+      states.length = 0;
       Object.assign(states, data.states);
       for (const state of data.states) {
         sessionsByState[state.state] = data.heroSessions.filter(x =>

--- a/apps/chromealive-ui/src/pages/pagestate-popup/index.vue
+++ b/apps/chromealive-ui/src/pages/pagestate-popup/index.vue
@@ -2,7 +2,7 @@
   <img :src="ICON_CARET" class="caret" />
   <div id="pagestate-popup">
     <div class="wrapper">
-      <h5>New Page State Found</h5>
+      <h5>{{pageStateMessage()}}</h5>
 
       <button @click.prevent="openPageState()">Open Generator</button>
     </div>
@@ -26,6 +26,9 @@ export default Vue.defineComponent({
     openPageState() {
       (window as any).openPageState();
     },
+    pageStateMessage(): string {
+      return (window as any).pageStateMessage() ?? 'New Page State Found';
+    }
   },
 });
 </script>

--- a/commons/lib/IpcUtils.ts
+++ b/commons/lib/IpcUtils.ts
@@ -1,13 +1,8 @@
 import * as os from 'os';
-import { v1 as uuidv1 } from 'uuid';
 
 export function createIpcSocketPath(name: string): string {
   if (os.platform() === 'win32') {
     return `\\\\.\\pipe\\${name}`;
   }
   return `${os.tmpdir()}/${name}.sock`;
-}
-
-export function createId(): string {
-  return uuidv1();
 }

--- a/commons/package.json
+++ b/commons/package.json
@@ -5,8 +5,7 @@
   "scripts": {},
   "dependencies": {
     "https-proxy-agent": "^5.0.0",
-    "source-map-support": "^0.5.19",
-    "uuid": "^8.3.2"
+    "source-map-support": "^0.5.19"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^5.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11767,7 +11767,7 @@ nanoid@^3.1.25:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.28.tgz#3c01bac14cb6c5680569014cc65a2f26424c6bd4"
   integrity sha512-gSu9VZ2HtmoKYe/lmyPFES5nknFrHa+/DT9muUFWFMi6Jh9E1I7bkvlQ8xxf1Kos9pi9o8lBnIOkatMhKX/YUw==
 
-nanoid@^3.1.28:
+nanoid@^3.1.28, nanoid@^3.1.30:
   version "3.1.30"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.30.tgz#63f93cc548d2a113dc5dfbc63bfa09e2b9b64362"
   integrity sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==


### PR DESCRIPTION
- Add ability to "extend" a timeline
- Auto-load to the full "load" time of a script
- Fix issue where service worker was disconnecting and not coming back (requires "Target detach + routing messages to Core via ContentScript)
- Run databoxes from their original working directory
- Convert to nanoids