### PR TITLE
feat(commons): ulixee config

### DIFF
--- a/apps/boss/package.json
+++ b/apps/boss/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@ulixee/apps-chromealive-core": "1.5.4",
     "@ulixee/default-browser-emulator": "1.5.4",
-    "@ulixee/commons": "1.5.7",
+    "@ulixee/commons": "1.5.8",
     "@ulixee/server": "1.5.4",
     "electron-positioner": "^4.1.0",
     "tar": "^6.1.11",

--- a/apps/chromealive-core/lib/SessionObserver.ts
+++ b/apps/chromealive-core/lib/SessionObserver.ts
@@ -19,6 +19,7 @@ import TabGroupModule from './hero-plugin-modules/TabGroupModule';
 import TimetravelPlayer from '@ulixee/hero-timetravel/player/TimetravelPlayer';
 import ChromeAliveCore from '../index';
 import TimelineRecorder from '@ulixee/hero-timetravel/lib/TimelineRecorder';
+import AliveBarPositioner from './AliveBarPositioner';
 
 const { log } = Log(module);
 
@@ -34,6 +35,7 @@ export default class SessionObserver extends TypedEventEmitter<{
 
   public readonly timetravelPlayer: TimetravelPlayer;
   public readonly timelineRecorder: TimelineRecorder;
+  public readonly scriptInstanceMeta: IScriptInstanceMeta;
 
   private waitForPageStateEvents: {
     id: string;
@@ -44,7 +46,6 @@ export default class SessionObserver extends TypedEventEmitter<{
   }[] = [];
 
   private scriptLastModifiedTime: number;
-  private readonly scriptInstanceMeta: IScriptInstanceMeta;
   private databoxSession: DataboxSession;
   private outputRebuilder = new OutputRebuilder();
   private databoxInput: any = null;
@@ -108,6 +109,7 @@ export default class SessionObserver extends TypedEventEmitter<{
   ): Error | undefined {
     if (startLocation === 'sessionStart') {
       ChromeAliveCore.restartingHeroSessionId = this.heroSession.id;
+      AliveBarPositioner.restartingSession(this.heroSession.id);
     }
     const script = this.scriptInstanceMeta.entrypoint;
     const execArgv = [

--- a/apps/chromealive-core/package.json
+++ b/apps/chromealive-core/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "@ulixee/hero-interfaces": "1.5.4",
-    "@ulixee/commons": "1.5.7",
+    "@ulixee/commons": "1.5.8",
     "@ulixee/hero-plugin-utils": "1.5.4",
     "@ulixee/hero-puppet-chrome": "1.5.4",
     "@ulixee/default-browser-emulator": "1.5.4",

--- a/apps/chromealive-extension/package.json
+++ b/apps/chromealive-extension/package.json
@@ -18,7 +18,7 @@
     "@headlessui/vue": "^1.4.1",
     "@heroicons/vue": "^1.0.4",
     "@tailwindcss/forms": "^0.3.3",
-    "@ulixee/commons": "1.5.7",
+    "@ulixee/commons": "1.5.8",
     "@ulixee/apps-chromealive-core": "1.5.4",
     "@webcomponents/custom-elements": "^1.5.0",
     "core-js": "^3.6.5",

--- a/apps/chromealive-ui/package.json
+++ b/apps/chromealive-ui/package.json
@@ -17,7 +17,7 @@
     "vue-json-pretty": "^1.7.1",
     "json5": "^2.2.0",
     "@ulixee/apps-chromealive-interfaces": "1.5.4",
-    "@ulixee/commons": "1.5.7"
+    "@ulixee/commons": "1.5.8"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "~4.5.0",

--- a/apps/chromealive-ui/src/pages/app/views/Live.vue
+++ b/apps/chromealive-ui/src/pages/app/views/Live.vue
@@ -205,6 +205,10 @@ export default Vue.defineComponent({
         this,
         tick?.id as string,
       );
+      (this.focusedPageState.window as any).pageStateIsResolving = this.pageStateIsResolving.bind(
+        this,
+        tick?.id as string,
+      );
       this.focusedPageState.window.addEventListener('close', () => {
         this.focusedPageState.window = null;
       });
@@ -376,6 +380,13 @@ export default Vue.defineComponent({
       return pageState.isUnresolved
         ? 'New Page State Found'
         : `Page State: ${pageState.resolvedState ?? '...'}`;
+    },
+
+    pageStateIsResolving(pageStateId?: string): boolean {
+      const pageState =
+        this.session.pageStates.find(x => x.id === pageStateId) ??
+        this.session.pageStates[this.session.pageStates.length - 1];
+      return !pageState.isUnresolved && !pageState.resolvedState;
     },
 
     openPageState(pageStateId?: string) {

--- a/apps/chromealive-ui/src/pages/pagestate-popup/index.vue
+++ b/apps/chromealive-ui/src/pages/pagestate-popup/index.vue
@@ -2,7 +2,8 @@
   <img :src="ICON_CARET" class="caret" />
   <div id="pagestate-popup">
     <div class="wrapper">
-      <h5>{{pageStateMessage()}}</h5>
+      <h5 v-if="!pageStateIsResolving()">{{pageStateMessage()}}</h5>
+      <h5 class="loading" v-else>Page State</h5>
 
       <button @click.prevent="openPageState()">Open Generator</button>
     </div>
@@ -28,6 +29,9 @@ export default Vue.defineComponent({
     },
     pageStateMessage(): string {
       return (window as any).pageStateMessage() ?? 'New Page State Found';
+    },
+    pageStateIsResolving(): string {
+      return (window as any).pageStateIsResolving() ?? false;
     }
   },
 });
@@ -86,6 +90,16 @@ body {
     text-align: center;
     text-transform: uppercase;
     margin-top: 20px;
+
+    &.loading {
+      opacity: 0.6;
+      cursor: not-allowed;
+      background-image: url('~@/assets/icons/loading-bars.svg');
+      background-position: center right;
+      background-repeat: no-repeat;
+      background-size: 10px;
+      padding-right: 25px;
+    }
   }
 
 

--- a/apps/chromealive/package.json
+++ b/apps/chromealive/package.json
@@ -26,7 +26,7 @@
     "tar": "^6.1.11",
     "compare-versions": "^3.6.0",
     "electron-log": "^4.4.1",
-    "@ulixee/commons": "^1.5.5",
+    "@ulixee/commons": "1.5.8",
     "@ulixee/apps-chromealive-interfaces": "^1.5.4",
     "electron-context-menu": "^3.1.1",
     "ws": "^7.4.6"

--- a/commons/config/index.ts
+++ b/commons/config/index.ts
@@ -1,0 +1,117 @@
+import * as Fs from 'fs';
+import * as Path from 'path';
+import { getCacheDirectory } from '../lib/dirUtils';
+
+export default class UlixeeConfig {
+  public static get global(): UlixeeConfig {
+    this.globalConfig ??= new UlixeeConfig(this.globalConfigDirectory);
+    return this.globalConfig;
+  }
+
+  public static isCacheEnabled = process.env.NODE_END === 'production';
+
+  private static globalConfigDirectory = Path.join(getCacheDirectory(), 'ulixee');
+  private static globalConfig: UlixeeConfig;
+
+  private static configDirectoryName = '.ulixee';
+  private static cachedConfigLocations: { [cwd_entrypoint: string]: string } = {};
+  private static cachedConfigObjects: { [cwd_entrypoint: string]: UlixeeConfig } = {};
+
+  public serverHost?: string;
+
+  private get configPath(): string {
+    return Path.join(this.directoryPath, 'config.json');
+  }
+
+  constructor(readonly directoryPath: string) {
+    if (Fs.existsSync(this.configPath)) {
+      const data = JSON.parse(Fs.readFileSync(this.configPath, 'utf8'));
+      this.serverHost = data.serverHost;
+    }
+  }
+
+  public async setGlobalDefaults(): Promise<void> {
+    this.serverHost ??= 'localhost:1337';
+    await this.save();
+  }
+
+  public save(): Promise<void> {
+    return Fs.promises.writeFile(this.configPath, JSON.stringify(this.getData(), null, 2));
+  }
+
+  private getData(): IUlixeeConfig {
+    return {
+      serverHost: this.serverHost,
+    };
+  }
+
+  public static load(runtimeLocation?: IRuntimeLocation): UlixeeConfig {
+    runtimeLocation = this.useRuntimeLocationDefaults(runtimeLocation);
+    const key = this.getLocationKey(runtimeLocation);
+    if (!this.cachedConfigObjects[key]) {
+      const directory = this.findConfigDirectory(runtimeLocation);
+      if (!this.isCacheEnabled) return new UlixeeConfig(directory);
+
+      this.cachedConfigObjects[key] = new UlixeeConfig(directory);
+    }
+    return this.cachedConfigObjects[key];
+  }
+
+  public static findConfigDirectory(runtimeLocation?: IRuntimeLocation): string {
+    runtimeLocation = this.useRuntimeLocationDefaults(runtimeLocation);
+    const key = this.getLocationKey(runtimeLocation);
+    if (!this.cachedConfigLocations[key]) {
+      const configDirectory = this.traverseDirectories(runtimeLocation);
+      if (!this.isCacheEnabled) return configDirectory;
+
+      this.cachedConfigLocations[key] = configDirectory;
+    }
+
+    return this.cachedConfigLocations[key];
+  }
+
+  private static useRuntimeLocationDefaults(runtimeLocation?: IRuntimeLocation): IRuntimeLocation {
+    return {
+      entrypoint: runtimeLocation?.entrypoint ?? require.main?.filename ?? process.argv[1],
+      workingDirectory: runtimeLocation?.workingDirectory ?? process.cwd(),
+    };
+  }
+
+  private static getLocationKey(runtimeLocation: IRuntimeLocation): string {
+    return `${runtimeLocation.workingDirectory}_${runtimeLocation.entrypoint}`;
+  }
+
+  private static traverseDirectories(runtimeLocation: IRuntimeLocation): string {
+    const { entrypoint, workingDirectory } = runtimeLocation;
+    // look up hierarchy from the entrypoint of the script
+    let currentPath = Path.dirname(entrypoint);
+    do {
+      const upDirectory = Path.normalize(Path.join(currentPath, '..'));
+      if (upDirectory === currentPath) break;
+      currentPath = upDirectory;
+
+      const configPath = this.hasConfigDirectory(currentPath);
+      if (configPath) return configPath;
+    } while (currentPath.length && Fs.existsSync(currentPath));
+
+    const configPath = this.hasConfigDirectory(workingDirectory);
+    if (configPath) return configPath;
+
+    // global directory is the working directory
+    return this.globalConfigDirectory;
+  }
+
+  private static hasConfigDirectory(path: string): string {
+    const pathToCheck = Path.normalize(Path.join(path, this.configDirectoryName));
+    if (Fs.existsSync(pathToCheck) && Fs.statSync(pathToCheck).isDirectory()) return pathToCheck;
+  }
+}
+
+export interface IUlixeeConfig {
+  serverHost: string;
+}
+
+export interface IRuntimeLocation {
+  workingDirectory: string;
+  entrypoint: string;
+}

--- a/commons/package.json
+++ b/commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ulixee/commons",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "Common utilities for Ulixee",
   "scripts": {},
   "dependencies": {

--- a/commons/test/utils.test.ts
+++ b/commons/test/utils.test.ts
@@ -1,4 +1,7 @@
-import { escapeUnescapedChar } from '../lib/utils';
+import * as Utils from '../lib/utils';
+import { bindFunctions } from '../lib/utils';
+
+const { escapeUnescapedChar } = Utils;
 
 test('should escape unescaped regex chars', () => {
   const result = escapeUnescapedChar('http://test.com?param=1', '?');
@@ -8,4 +11,38 @@ test('should escape unescaped regex chars', () => {
 test('should not escape already unescaped regex chars', () => {
   const result = escapeUnescapedChar('http://test.com\\?param=1', '?');
   expect(result).toBe('http://test.com\\?param=1');
+});
+
+test('should get all functions of an object hierarchy', () => {
+  class BaseClass {
+    method1() {}
+    method2() {}
+  }
+
+  class TestClass extends BaseClass {
+    method3() {}
+  }
+
+  const instance = new TestClass();
+  const hierarchy = Utils.getPrototypeHierarchy(instance);
+  expect(hierarchy[0]).toEqual(BaseClass.prototype);
+  expect(hierarchy[1]).toEqual(TestClass.prototype);
+  expect(hierarchy[2]).toEqual(instance);
+  // cache should return the same set
+  expect(Utils.getPrototypeHierarchy(instance)).toEqual(hierarchy);
+
+  bindFunctions(instance);
+
+  expect([...Utils.getObjectFunctionProperties(BaseClass.prototype)]).toEqual([
+    'method1',
+    'method2',
+  ]);
+  expect([...Utils.getObjectFunctionProperties(TestClass.prototype)]).toEqual(['method3']);
+
+  // should bind all methods
+  expect([...Utils.getObjectFunctionProperties(instance)]).toEqual([
+    'method1',
+    'method2',
+    'method3',
+  ]);
 });

--- a/server/cli-commands/package.json
+++ b/server/cli-commands/package.json
@@ -3,7 +3,7 @@
   "version": "1.5.4",
   "description": "The server CLI",
   "dependencies": {
-    "@ulixee/commons": "1.5.7",
+    "@ulixee/commons": "1.5.8",
     "@ulixee/server": "1.5.4",
     "yargs-parser": "^20.2.9"
   },

--- a/server/main/lib/DataboxCoreConnector.ts
+++ b/server/main/lib/DataboxCoreConnector.ts
@@ -18,6 +18,10 @@ export default class DataboxCoreConnector extends BaseCoreConnector {
     this.server = server;
   }
 
+  public async start() {
+    await Core.start();
+  }
+
   public async close() {
     await Core.shutdown();
   }

--- a/server/main/package.json
+++ b/server/main/package.json
@@ -7,7 +7,7 @@
     "start:alive": "node -r @ulixee/apps-chromealive-core/register ../cli-commands/bin/start.js"
   },
   "dependencies": {
-    "@ulixee/commons": "1.5.7",
+    "@ulixee/commons": "1.5.8",
     "@ulixee/hero-core": "1.5.4",
     "@ulixee/databox-core": "1.5.4",
     "@ulixee/hero-plugin-utils": "1.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6805,7 +6805,7 @@ dns-packet@^1.3.1:
     ip "^1.1.0"
     safe-buffer "^5.0.1"
 
-dns-packet@^5.2.1:
+dns-packet@^5.2.4:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-5.3.0.tgz#9a0f66118d3be176b828b911a842b0b1a4bdfd4f"
   integrity sha512-Nce7YLu6YCgWRvOmDBsJMo9M5/jV3lEZ5vUWnWXYmwURvPylHvq7nkDWhNmk1ZQoZZOP7oQh/S0lSxbisKOfHg==
@@ -7070,15 +7070,6 @@ electron-to-chromium@^1.3.793:
   version "1.3.806"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.806.tgz#21502100f11aead6c501d1cd7f2504f16c936642"
   integrity sha512-AH/otJLAAecgyrYp0XK1DPiGVWcOgwPeJBOLeuFQ5l//vhQhwC9u6d+GijClqJAmsHG4XDue81ndSQPohUu0xA==
-
-electron@13.1.7:
-  version "13.1.7"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-13.1.7.tgz#7e17f5c93a8d182a2a486884fed3dc34ab101be9"
-  integrity sha512-sVfpP/0s6a82FK32LMuEe9L+aWZw15u3uYn9xUJArPjy4OZHteE6yM5871YCNXNiDnoCLQ5eqQWipiVgHsf8nQ==
-  dependencies:
-    "@electron/get" "^1.0.1"
-    "@types/node" "^14.6.2"
-    extract-zip "^1.0.3"
 
 electron@13.1.9:
   version "13.1.9"
@@ -15529,10 +15520,10 @@ tar@^6.0.2, tar@^6.1.0:
     mkdirp "^1.0.3"
     yallist "^4.0.0"
 
-tar@^6.1.10:
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.10.tgz#8a320a74475fba54398fa136cd9883aa8ad11175"
-  integrity sha512-kvvfiVvjGMxeUNB6MyYv5z7vhfFRwbwCXJAeL0/lnbrttBVqcMOnpHUf0X42LrPMR8mMpgapkJMchFH4FSHzNA==
+tar@^6.1.11:
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
+  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"
@@ -16966,7 +16957,7 @@ ws@^6.0.0, ws@^6.2.1:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^7.4.4, ws@^7.4.6:
+ws@^7.4.6:
   version "7.5.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.3.tgz#160835b63c7d97bfab418fc1b8a9fced2ac01a74"
   integrity sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==


### PR DESCRIPTION
Adds a Ulixee Config file. We look in current script instance runtime path by default, and the global cache directory if nothing exists there.

Menubar now loads from this global file and creates it on first run if not existing.

Fixes:
- Add loading state to PageState popup when still loading
- AliveBarPositioner should handle restarted scripts
- Cache "bindFunctions" results so we don't have to recalculate for every instance