### PR TITLE
feat(chromealive): about page for circuit

### DIFF
--- a/apps/chromealive-core/apis/AppApi.ts
+++ b/apps/chromealive-core/apis/AppApi.ts
@@ -1,6 +1,7 @@
 import { IBounds } from '@ulixee/apps-chromealive-interfaces/IBounds';
 import { IAppApiStatics } from '@ulixee/apps-chromealive-interfaces/apis/IAppApi';
 import AliveBarPositioner from '../lib/AliveBarPositioner';
+import ChromeAliveCore from '../index';
 
 @IAppApiStatics
 export default class AppApi {
@@ -8,7 +9,8 @@ export default class AppApi {
     return {};
   }
 
-  static ready(args: { workarea: IBounds }): void {
+  static ready(args: { workarea: IBounds; vueServer: string }): void {
+    ChromeAliveCore.vueServer = args.vueServer;
     AliveBarPositioner.onAppReady(args.workarea);
   }
 

--- a/apps/chromealive-core/apis/PageStateApi.ts
+++ b/apps/chromealive-core/apis/PageStateApi.ts
@@ -25,12 +25,12 @@ export default class PageStateApi {
     getPageStateManager().renameState(args.state, args.oldValue);
   }
 
-  static removeState(args: { state: string }): void {
-    getPageStateManager().removeState(args.state);
+  static async removeState(args: { state: string }): Promise<void> {
+    await getPageStateManager().removeState(args.state);
   }
 
-  static unfocusSession(): void {
-    getPageStateManager().unfocusSession();
+  static async unfocusSession(): Promise<void> {
+    await getPageStateManager().unfocusSession();
   }
 
   static async openSession(args: { heroSessionId: string }): Promise<void> {
@@ -49,7 +49,10 @@ export default class PageStateApi {
     await pageStateManager.changeSessionLoadingTimeBoundary(args.timelineOffset, args.isStartTime);
   }
 
-  static async extendSessionTime(args: { heroSessionId: string; addMillis: number }): Promise<void> {
+  static async extendSessionTime(args: {
+    heroSessionId: string;
+    addMillis: number;
+  }): Promise<void> {
     const pageStateManager = getPageStateManager();
     await pageStateManager.extendSessionTime(args.heroSessionId, args.addMillis);
   }

--- a/apps/chromealive-core/index.ts
+++ b/apps/chromealive-core/index.ts
@@ -16,6 +16,7 @@ const { log } = Log(module);
 
 export default class ChromeAliveCore {
   public static sessionObserversById = new Map<string, SessionObserver>();
+  public static vueServer: string;
   public static get activeSessionObserver(): SessionObserver {
     return this.sessionObserversById.get(this.activeHeroSessionId);
   }

--- a/apps/chromealive-core/lib/AboutPage.ts
+++ b/apps/chromealive-core/lib/AboutPage.ts
@@ -1,0 +1,87 @@
+import { URL } from 'url';
+import ChromeAliveCore from '../index';
+import { Session as HeroSession } from '@ulixee/hero-core';
+import * as http from 'http';
+import { Protocol } from '@ulixee/hero-interfaces/IDevtoolsSession';
+import { IPuppetPage } from '@ulixee/hero-interfaces/IPuppetPage';
+import { httpGet } from '@ulixee/commons/lib/downloadFile';
+import { TypedEventEmitter } from '@ulixee/commons/lib/eventUtils';
+import { ISessionSummary } from '@ulixee/hero-interfaces/ICorePlugin';
+
+export default class AboutPage extends TypedEventEmitter<{ close: void }> {
+  private page: Promise<IPuppetPage>;
+
+  private aboutPages = {
+    circuits: 'about.html',
+  };
+
+  constructor(readonly heroSession: HeroSession) {
+    super();
+  }
+
+  public async open(aboutPage: keyof AboutPage['aboutPages']) {
+    const page = await this.openPuppetPage();
+    await page.navigate(`http://ulixee.about/${aboutPage}`);
+  }
+
+  public async close(): Promise<void> {
+    if (this.page) {
+      await this.page.then(x => x.close()).catch(() => null);
+    }
+  }
+
+  private async openPuppetPage(): Promise<IPuppetPage> {
+    if (this.page) return this.page;
+
+    this.page = this.heroSession.browserContext.newPage({ runPageScripts: false });
+
+    const page = await this.page;
+    page.once('close', () => {
+      this.page = null;
+      this.emit('close');
+    });
+    for (const plugin of this.heroSession.plugins.corePlugins) {
+      if (plugin.onNewPuppetPage) await plugin.onNewPuppetPage(page, this.sessionSummary());
+    }
+    this.heroSession.mitmRequestSession.blockedResources.urls.push('http://ulixee.about/*');
+    await page.setNetworkRequestInterceptor(
+      this.routeNetworkToVueApp.bind(this, 'http://ulixee.about'),
+    );
+    return page;
+  }
+
+  private sessionSummary(): ISessionSummary {
+    return {
+      id: this.heroSession.id,
+      options: this.heroSession.options,
+    };
+  }
+
+  private async routeNetworkToVueApp(
+    domain: string,
+    request: Protocol.Fetch.RequestPausedEvent,
+  ): Promise<Protocol.Fetch.FulfillRequestRequest | Protocol.Fetch.ContinueRequestRequest> {
+    if (!request.request.url.startsWith(domain)) return;
+
+    const url = new URL(request.request.url);
+    url.host = ChromeAliveCore.vueServer.replace('http://', '');
+    url.protocol = 'http';
+    const mapping = this.aboutPages[url.pathname.slice(1)];
+    if (mapping) {
+      url.pathname = `/${mapping}`;
+    }
+    const res = await new Promise<http.IncomingMessage>(resolve => httpGet(url.href, resolve));
+    const bodyChunks: Buffer[] = [];
+    for await (const chunk of res) bodyChunks.push(chunk);
+
+    return {
+      requestId: request.requestId,
+      responseHeaders: Object.entries(res.headers).map(x => ({
+        name: x[0],
+        value: x[1] as string,
+      })),
+      responseCode: res.statusCode,
+      body: Buffer.concat(bodyChunks).toString('base64'),
+    } as Protocol.Fetch.FulfillRequestRequest;
+  }
+}

--- a/apps/chromealive-core/lib/bridges/BridgeToExtension.ts
+++ b/apps/chromealive-core/lib/bridges/BridgeToExtension.ts
@@ -36,11 +36,11 @@ export default class BridgeToExtension extends EventEmitter {
     const { devtoolsSession } = page;
     this.devtoolsSessionsByPageId[page.id] = devtoolsSession;
 
-    page.on('close', () => {
+    page.once('close', () => {
       this.closePuppetPage(page);
       delete this.devtoolsSessionsByPageId[page.id];
     });
-    page.on('close', () => this.closePuppetPage(page));
+    page.once('close', () => this.closePuppetPage(page));
 
     devtoolsSession.on('Runtime.executionContextCreated', event => {
       this.onContextCreated(page, event);

--- a/apps/chromealive-core/lib/hero-plugin-modules/DevtoolsPanelModule.ts
+++ b/apps/chromealive-core/lib/hero-plugin-modules/DevtoolsPanelModule.ts
@@ -3,6 +3,7 @@ import BridgeToDevtoolsPrivate from '../bridges/BridgeToDevtoolsPrivate';
 import { ISessionSummary } from '@ulixee/hero-interfaces/ICorePlugin';
 import TabGroupModule from './TabGroupModule';
 import { CanceledPromiseError } from '@ulixee/commons/interfaces/IPendingWaitEvent';
+import IPuppetContext from '@ulixee/hero-interfaces/IPuppetContext';
 
 export default class DevtoolsPanelModule {
   public static bySessionId = new Map<string, DevtoolsPanelModule>();
@@ -15,13 +16,12 @@ export default class DevtoolsPanelModule {
     this.bridgeToDevtoolsPrivate = bridgeToDevtoolsPrivate;
   }
 
-  public onNewPuppetPage(page: IPuppetPage, session: ISessionSummary): Promise<any> {
-    const sessionId = session.id;
-    DevtoolsPanelModule.bySessionId.set(sessionId, this);
+  public onNewPuppetContext(context: IPuppetContext, session: ISessionSummary): void {
+    DevtoolsPanelModule.bySessionId.set(session.id, this);
+  }
 
-    page.browserContext.once('close', () => DevtoolsPanelModule.bySessionId.delete(sessionId));
-
-    return Promise.resolve();
+  public close(session: ISessionSummary): void {
+    DevtoolsPanelModule.bySessionId.delete(session.id);
   }
 
   public async closeDevtoolsPanelForPage(page: IPuppetPage): Promise<void> {

--- a/apps/chromealive-interfaces/apis/IAppApi.ts
+++ b/apps/chromealive-interfaces/apis/IAppApi.ts
@@ -5,7 +5,7 @@ export default interface IAppApi {
     error?: Error;
   };
 
-  ready(args: { workarea: IBounds }): void;
+  ready(args: { workarea: IBounds; vueServer: string }): void;
   focus(): void;
 }
 

--- a/apps/chromealive-interfaces/apis/IPageStateApi.ts
+++ b/apps/chromealive-interfaces/apis/IPageStateApi.ts
@@ -4,8 +4,8 @@ export default interface IPageStateApi {
   renameState(args: { state: string; oldValue: string }): void;
   addState(args: { heroSessionIds: string[]; state: string }): void;
   spawnSession(): Promise<void>;
-  removeState(args: { state: string }): void;
-  unfocusSession(): void;
+  removeState(args: { state: string }): Promise<void>;
+  unfocusSession(): Promise<void>;
   openSession(args: { heroSessionId: string }): Promise<void>;
   modifySessionTimes(args: {
     heroSessionId: string;

--- a/apps/chromealive-ui/src/pages/about/index.css
+++ b/apps/chromealive-ui/src/pages/about/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/chromealive-ui/src/pages/about/index.ts
+++ b/apps/chromealive-ui/src/pages/about/index.ts
@@ -1,0 +1,5 @@
+import { createApp } from 'vue'
+import App from './index.vue'
+import './index.css';
+
+createApp(App).mount('#app')

--- a/apps/chromealive-ui/src/pages/about/index.vue
+++ b/apps/chromealive-ui/src/pages/about/index.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="container-md mx-auto">
+    <div id="circuits" v-if="mode === 'circuits'">
+      <h1>About Circuits</h1>
+      <p>
+        Circuits allow you to define and then detect what Location or State your Hero World is in.
+      </p>
+      <p>
+        Locations and States are called "Gates". Each Gate can contain 1 or more assertions that
+        make it a unique state.
+      </p>
+      <p>
+        Superhero comes with a visual designer to help you sort various World's you've encountered
+        into Gates
+      </p>
+      <p>
+        Gates help you create branches of code for dealing with the different states you might
+        encounter, such as:
+      </p>
+
+      <ul>
+        <li>Redirections</li>
+        <li>Popups</li>
+        <li>Blocked</li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import * as Vue from 'vue';
+import { ChevronRightIcon } from '@heroicons/vue/solid';
+
+export default Vue.defineComponent({
+  name: 'About',
+  components: { ChevronRightIcon },
+  setup() {
+    return {
+      mode: Vue.ref<string>('circuits'),
+    };
+  },
+  methods: {},
+  mounted() {
+    this.mode = location.pathname.split('/').pop();
+  }
+});
+</script>
+
+<style lang="scss">
+#app {
+  display: flex;
+}
+h1 {
+  @apply font-bold py-3;
+}
+p {
+  @apply py-2
+}
+li {
+  @apply list-disc px-1 mx-5;
+}
+</style>

--- a/apps/chromealive-ui/vue.config.js
+++ b/apps/chromealive-ui/vue.config.js
@@ -6,5 +6,6 @@ module.exports = {
     databox: './src/pages/databox/index.ts',
     'pagestate-panel': './src/pages/pagestate-panel/index.ts',
     'pagestate-popup': './src/pages/pagestate-popup/index.ts',
+    about: './src/pages/about/index.ts',
   },
 };


### PR DESCRIPTION
Top level flow for circuits:
1. Focus on live session when entering circuit designer (currently called page state generator)
2. When entering a gate, if the focused session matches, keep it
3. If no match, select the first session in the gate
4. When returning to the circuit top level view, deselect any focused session

Also in this PR:
- We were hitting the nodejs event emitter warning limit, so I refactored some HeroCorePlugin module handlers listening to browser context close events.