### PR TITLE
Sourcemap & Sourcecode loading

### DIFF
--- a/apps/boss/package.json
+++ b/apps/boss/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@ulixee/apps-chromealive-core": "1.5.4",
     "@ulixee/default-browser-emulator": "1.5.4",
-    "@ulixee/commons": "1.5.8",
+    "@ulixee/commons": "1.5.9",
     "@ulixee/server": "1.5.4",
     "electron-positioner": "^4.1.0",
     "tar": "^6.1.11",

--- a/apps/chromealive-core/package.json
+++ b/apps/chromealive-core/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "@ulixee/hero-interfaces": "1.5.4",
-    "@ulixee/commons": "1.5.8",
+    "@ulixee/commons": "1.5.9",
     "@ulixee/hero-plugin-utils": "1.5.4",
     "@ulixee/hero-puppet-chrome": "1.5.4",
     "@ulixee/default-browser-emulator": "1.5.4",

--- a/apps/chromealive-extension/package.json
+++ b/apps/chromealive-extension/package.json
@@ -18,7 +18,7 @@
     "@headlessui/vue": "^1.4.1",
     "@heroicons/vue": "^1.0.4",
     "@tailwindcss/forms": "^0.3.3",
-    "@ulixee/commons": "1.5.8",
+    "@ulixee/commons": "1.5.9",
     "@ulixee/apps-chromealive-core": "1.5.4",
     "@webcomponents/custom-elements": "^1.5.0",
     "core-js": "^3.6.5",

--- a/apps/chromealive-ui/package.json
+++ b/apps/chromealive-ui/package.json
@@ -20,7 +20,7 @@
     "vue-json-pretty": "^1.7.1",
     "json5": "^2.2.0",
     "@ulixee/apps-chromealive-interfaces": "1.5.4",
-    "@ulixee/commons": "1.5.8"
+    "@ulixee/commons": "1.5.9"
   },
   "devDependencies": {
     "@tailwindcss/postcss7-compat": "^2.2.7",

--- a/apps/chromealive-ui/src/pages/pagestate-panel/index.vue
+++ b/apps/chromealive-ui/src/pages/pagestate-panel/index.vue
@@ -344,7 +344,6 @@ export default Vue.defineComponent({
       if (this.editingStateName || this.draggingSessionId) return;
       this.focusedStateName = state.state;
 
-      console.log('focus on state', state.state, state.heroSessionIds, this.focusedSessionId);
       if (!state.heroSessionIds.includes(this.focusedSessionId)) {
         const firstSession = this.data.heroSessions.find(x => x.id === state.heroSessionIds[0]);
         if (firstSession) {

--- a/apps/chromealive/package.json
+++ b/apps/chromealive/package.json
@@ -26,7 +26,7 @@
     "tar": "^6.1.11",
     "compare-versions": "^3.6.0",
     "electron-log": "^4.4.1",
-    "@ulixee/commons": "1.5.8",
+    "@ulixee/commons": "1.5.9",
     "@ulixee/apps-chromealive-interfaces": "^1.5.4",
     "electron-context-menu": "^3.1.1",
     "ws": "^7.4.6"

--- a/commons/interfaces/ISourceCodeLocation.ts
+++ b/commons/interfaces/ISourceCodeLocation.ts
@@ -1,0 +1,5 @@
+export default interface ISourceCodeLocation {
+  filename: string;
+  line: number;
+  column: number;
+}

--- a/commons/lib/SourceLoader.ts
+++ b/commons/lib/SourceLoader.ts
@@ -1,0 +1,27 @@
+import ISourceCodeLocation from '../interfaces/ISourceCodeLocation';
+import { SourceMapSupport } from './SourceMapSupport';
+
+export default class SourceLoader {
+  private static sourceLines: { [source: string]: string[] } = {};
+
+  static getSource(codeLocation: ISourceCodeLocation): ISourceCodeLocation & { code: string } {
+    const originalSourcePosition = SourceMapSupport.getOriginalSourcePosition(codeLocation);
+    if (originalSourcePosition.source !== codeLocation.filename) {
+      codeLocation = {
+        line: originalSourcePosition.line,
+        filename: originalSourcePosition.source,
+        column: originalSourcePosition.column,
+      };
+    }
+    if (!this.sourceLines[codeLocation.filename]) {
+      const file = SourceMapSupport.getFileContents(codeLocation.filename);
+      this.sourceLines[codeLocation.filename] = file.split(/\r?\n/);
+    }
+
+    const code = this.sourceLines[codeLocation.filename][codeLocation.line - 1];
+    return {
+      code,
+      ...codeLocation,
+    };
+  }
+}

--- a/commons/lib/SourceMapSupport.ts
+++ b/commons/lib/SourceMapSupport.ts
@@ -1,6 +1,265 @@
-import { install } from 'source-map-support';
+import { MappedPosition, SourceMapConsumer } from 'source-map-js';
+import * as fs from 'fs';
+import * as path from 'path';
+import ISourceCodeLocation from '../interfaces/ISourceCodeLocation';
+import { URL } from 'url';
 
-if (!Error[Symbol.for('source-map-support')]) {
-  Error[Symbol.for('source-map-support')] = true;
-  install({ handleUncaughtExceptions: false });
+// ATTRIBUTION: forked from https://github.com/evanw/node-source-map-support
+
+const sourceMapDataUrlRegex = /^data:application\/json[^,]+base64,/;
+const sourceMapUrlRegex =
+  /(?:\/\/[@#][\s]*sourceMappingURL=([^\s'"]+)[\s]*$)|(?:\/\*[@#][\s]*sourceMappingURL=([^\s*'"]+)[\s]*(?:\*\/)[\s]*$)/gm;
+const fileUrlPrefix = 'file://';
+
+export class SourceMapSupport {
+  private static sourceMapCache: { [source: string]: { map: SourceMapConsumer; url: string } } = {};
+  private static resolvedPathCache: { [file_url: string]: string } = {};
+  private static fileContentsCache: { [filepath: string]: string } = {};
+
+  static resetCache(): void {
+    this.sourceMapCache = {};
+    this.resolvedPathCache = {};
+    this.fileContentsCache = {};
+  }
+
+  static install(): void {
+    if (!Error[Symbol.for('source-map-support')]) {
+      Error[Symbol.for('source-map-support')] = true;
+      Error.prepareStackTrace = this.prepareStackTrace.bind(this);
+    }
+  }
+
+  static getOriginalSourcePosition(position: ISourceCodeLocation): MappedPosition {
+    this.sourceMapCache[position.filename] ??= this.retrieveSourceMap(position.filename);
+
+    const sourceMap = this.sourceMapCache[position.filename];
+    if (sourceMap?.map) {
+      const originalPosition = sourceMap.map.originalPositionFor(position);
+
+      // Only return the original position if a matching line was found
+      if (originalPosition.source) {
+        originalPosition.source = this.resolvePath(sourceMap.url, originalPosition.source);
+        return originalPosition;
+      }
+    }
+
+    return {
+      source: position.filename,
+      line: position.line,
+      column: position.column,
+    };
+  }
+
+  static getFileContents(filepath: string, cache = true): string {
+    if (this.fileContentsCache[filepath]) return this.fileContentsCache[filepath];
+
+    const originalFilepath = filepath;
+    // Trim the path to make sure there is no extra whitespace.
+    let lookupFilepath: string | URL = filepath.trim();
+    if (filepath.startsWith(fileUrlPrefix)) {
+      lookupFilepath = new URL(filepath);
+    }
+
+    let data: string = null;
+    try {
+      data = fs.readFileSync(lookupFilepath, 'utf8');
+    } catch (err) {
+      // couldn't read
+    }
+    if (cache) {
+      this.fileContentsCache[filepath] = data;
+      this.fileContentsCache[originalFilepath] = data;
+    }
+    return data;
+  }
+
+  private static prepareStackTrace(error: Error, stack: NodeJS.CallSite[]): string {
+    const name = error.name ?? error[Symbol.toStringTag] ?? error.constructor?.name ?? 'Error';
+    const message = error.message ?? '';
+    const errorString = name + ': ' + message;
+
+    // track fn name as we go backwards through stack
+    const processedStack = [];
+    let containingFnName: string = null;
+    for (let i = stack.length - 1; i >= 0; i--) {
+      let frame = stack[i];
+      if (frame.isNative()) {
+        containingFnName = null;
+      } else {
+        const filename = frame.getFileName() || (frame as any).getScriptNameOrSourceURL();
+        if (filename) {
+          const position = this.getOriginalSourcePosition({
+            filename,
+            line: frame.getLineNumber(),
+            column: frame.getColumnNumber() - 1,
+          });
+          if (position.source !== filename) {
+            const fnName = containingFnName ?? frame.getFunctionName();
+            containingFnName = position.name;
+            frame = new Proxy(frame, {
+              get(target: NodeJS.CallSite, p: string | symbol): any {
+                if (p === 'getFunctionName') return () => fnName;
+                if (p === 'getFileName') return () => position.source;
+                if (p === 'getScriptNameOrSourceURL') return () => position.source;
+                if (p === 'getLineNumber') return () => position.line;
+                if (p === 'getColumnNumber') return () => position.column + 1;
+                if (p === 'toString') return CallSiteToString.bind(frame);
+
+                return target[p]?.bind(target);
+              },
+            });
+          }
+        }
+      }
+
+      processedStack.unshift(`\n    at ${frame.toString()}`);
+    }
+    return errorString + processedStack.join('');
+  }
+
+  private static retrieveSourceMap(source: string): { url: string; map: SourceMapConsumer } {
+    const fileData = this.getFileContents(source, false);
+
+    // Find the *last* sourceMappingURL to avoid picking up sourceMappingURLs from comments, strings, etc.
+    let sourceMappingURL: string;
+    let sourceMapData: string;
+
+    let match: RegExpMatchArray;
+    while ((match = sourceMapUrlRegex.exec(fileData))) {
+      sourceMappingURL = match[1];
+    }
+
+    if (sourceMappingURL) {
+      if (sourceMapDataUrlRegex.test(sourceMappingURL)) {
+        const rawData = sourceMappingURL.slice(sourceMappingURL.indexOf(',') + 1);
+        sourceMapData = Buffer.from(rawData, 'base64').toString();
+        sourceMappingURL = source;
+      } else {
+        sourceMappingURL = this.resolvePath(source, sourceMappingURL);
+        sourceMapData = this.getFileContents(sourceMappingURL);
+      }
+    }
+
+    if (!sourceMapData) {
+      return {
+        url: null,
+        map: null,
+      };
+    }
+
+    const rawData = JSON.parse(sourceMapData);
+    return {
+      url: sourceMappingURL,
+      map: new SourceMapConsumer(rawData),
+    };
+  }
+
+  private static resolvePath(base: string, relative: string): string {
+    if (!base) return relative;
+    const key = `${base}__${relative}`;
+
+    if (!this.resolvedPathCache[key]) {
+      let protocol = base.startsWith(fileUrlPrefix) ? fileUrlPrefix : '';
+
+      let basePath = path.dirname(base).slice(protocol.length);
+
+      // handle file:///C:/ paths
+      if (protocol && /^\/\w:/.test(basePath)) {
+        protocol += '/';
+        basePath = basePath.slice(1);
+      }
+
+      this.resolvedPathCache[key] = protocol + path.resolve(basePath, relative);
+    }
+    return this.resolvedPathCache[key];
+  }
+}
+
+SourceMapSupport.install();
+
+// Converted from the V8 source code at:
+// https://github.com/v8/v8/blob/dc712da548c7fb433caed56af9a021d964952728/src/objects/stack-frame-info.cc#L344-L393
+function CallSiteToString(
+  this: NodeJS.CallSite & {
+    getScriptNameOrSourceURL(): string;
+    isAsync(): boolean;
+    isPromiseAll?(): boolean;
+    isPromiseAny?(): boolean;
+    getPromiseIndex?(): number;
+  },
+) {
+  let fileName;
+  let fileLocation = '';
+  if (this.isNative()) {
+    fileLocation = 'native';
+  } else {
+    fileName = this.getScriptNameOrSourceURL();
+    if (!fileName && this.isEval()) {
+      fileLocation = this.getEvalOrigin();
+      fileLocation += ', '; // Expecting source position to follow.
+    }
+
+    if (fileName) {
+      fileLocation += fileName;
+    } else {
+      // Source code does not originate from a file and is not native, but we
+      // can still get the source position inside the source string, e.g. in
+      // an eval string.
+      fileLocation += '<anonymous>';
+    }
+    const lineNumber = this.getLineNumber();
+    if (lineNumber != null) {
+      fileLocation += ':' + lineNumber;
+      const columnNumber = this.getColumnNumber();
+      if (columnNumber) {
+        fileLocation += ':' + columnNumber;
+      }
+    }
+  }
+
+  let line = '';
+  const isAsync = this.isAsync ? this.isAsync() : false;
+  if (isAsync) {
+    line += 'async ';
+    const isPromiseAll = this.isPromiseAll ? this.isPromiseAll() : false;
+    const isPromiseAny = this.isPromiseAny ? this.isPromiseAny() : false;
+    if (isPromiseAny || isPromiseAll) {
+      line += isPromiseAll ? 'Promise.all (index ' : 'Promise.any (index ';
+      const promiseIndex = this.getPromiseIndex();
+      line += promiseIndex + ')';
+    }
+  }
+  const functionName = this.getFunctionName();
+  let addSuffix = true;
+  const isConstructor = this.isConstructor();
+  const isMethodCall = !(this.isToplevel() || isConstructor);
+  if (isMethodCall) {
+    const typeName = this.getTypeName();
+    const methodName = this.getMethodName();
+    if (functionName) {
+      if (typeName && functionName.indexOf(typeName) != 0) {
+        line += typeName + '.';
+      }
+      line += functionName;
+      if (
+        methodName &&
+        functionName.indexOf('.' + methodName) != functionName.length - methodName.length - 1
+      ) {
+        line += ' [as ' + methodName + ']';
+      }
+    } else {
+      line += typeName + '.' + (methodName || '<anonymous>');
+    }
+  } else if (isConstructor) {
+    line += 'new ' + (functionName || '<anonymous>');
+  } else if (functionName) {
+    line += functionName;
+  } else {
+    line += fileLocation;
+    addSuffix = false;
+  }
+  if (addSuffix) {
+    line += ' (' + fileLocation + ')';
+  }
+  return line;
 }

--- a/commons/package.json
+++ b/commons/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@ulixee/commons",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "Common utilities for Ulixee",
   "scripts": {},
   "dependencies": {
     "https-proxy-agent": "^5.0.0",
-    "source-map-support": "^0.5.19"
+    "source-map-js": "^1.0.1"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^5.4.1",

--- a/commons/test/SourceLoader.test.ts
+++ b/commons/test/SourceLoader.test.ts
@@ -1,0 +1,15 @@
+import { getCallSite } from '../lib/utils';
+import SourceLoader from '../lib/SourceLoader';
+import ISourceCodeLocation from '../interfaces/ISourceCodeLocation';
+
+it('can lookup source code', function () {
+  let callSite: ISourceCodeLocation[];
+  // run code like this so we can see the true load (?? will be translated by typescript)
+  function loadCallsite() {
+    callSite ??= getCallSite();
+    return callSite;
+  }
+  const site = loadCallsite();
+  expect(SourceLoader.getSource(site[0]).code).toBe(`    callSite ??= getCallSite();`);
+  expect(SourceLoader.getSource(site[1]).code).toBe(`  const site = loadCallsite();`);
+});

--- a/commons/test/SourceMapSupport.test.ts
+++ b/commons/test/SourceMapSupport.test.ts
@@ -1,0 +1,295 @@
+import { SourceMapSupport } from '../lib/SourceMapSupport';
+import { SourceMapGenerator } from 'source-map-js';
+import * as fs from 'fs';
+import * as path from 'path';
+
+let counter = 0;
+
+beforeEach(() => {
+  jest.resetModules();
+  SourceMapSupport.resetCache();
+  counter += 1;
+});
+
+it('normal throw', function () {
+  const { full, inline } = createStackTraces(createMultiLineSourceMap(), [
+    'throw new Error("test");',
+  ]);
+
+  for (const stack of [full, inline]) {
+    expect(stack[0]).toBe('Error: test');
+    expect(stack[1]).toMatch(
+      /^    at Object\.<anonymous>\.exports\.test \((?:.*[/\\])?line1\.js:1001:101\)$/,
+    );
+  }
+});
+
+it('throw inside function', function () {
+  const { full, inline } = createStackTraces(createMultiLineSourceMap(), [
+    'function foo() {',
+    '  throw new Error("test");',
+    '}',
+    'foo();',
+  ]);
+
+  for (const stack of [full, inline]) {
+    expect(stack[0]).toBe('Error: test');
+    expect(stack[1]).toMatch(/^    at foo \((?:.*[/\\])?line2\.js:1002:102\)$/);
+    expect(stack[2]).toMatch(
+      /^    at Object\.<anonymous>\.exports\.test \((?:.*[/\\])?line4\.js:1004:104\)$/,
+    );
+  }
+});
+
+it('throw inside function inside function', function () {
+  const { full, inline } = createStackTraces(createMultiLineSourceMap(), [
+    'function foo() {',
+    '  function bar() {',
+    '    throw new Error("test");',
+    '  }',
+    '  bar();',
+    '}',
+    'foo();',
+  ]);
+
+  for (const stack of [full, inline]) {
+    expect(stack[0]).toBe('Error: test');
+    expect(stack[1]).toMatch(/^    at bar \((?:.*[/\\])?line3\.js:1003:103\)$/);
+    expect(stack[2]).toMatch(/^    at foo \((?:.*[/\\])?line5\.js:1005:105\)$/);
+    expect(stack[3]).toMatch(
+      /^    at Object\.<anonymous>\.exports\.test \((?:.*[/\\])?line7\.js:1007:107\)$/,
+    );
+  }
+});
+
+it('native function', function () {
+  const sourceMap = createEmptySourceMap();
+  sourceMap.addMapping({
+    generated: { line: 1, column: 0 },
+    original: { line: 1, column: 0 },
+    source: '.original.js',
+  });
+  const { full, inline } = createStackTraces(sourceMap, [
+    '[1].map(function(x) { throw new Error(x); });',
+  ]);
+
+  for (const stack of [full, inline]) {
+    expect(stack[0]).toBe('Error: 1');
+    expect(stack[1]).toMatch(/[/\\].original\.js/);
+    expect(stack[2]).toMatch(/at Array\.map \((native|<anonymous>)\)/);
+  }
+});
+
+it('function constructor', function () {
+  const { full, inline } = createStackTraces(createMultiLineSourceMap(), [
+    'throw new Function(")");',
+  ]);
+
+  for (const stack of [full, inline]) {
+    expect(stack[0]).toMatch(/SyntaxError: Unexpected token '?\)'?/);
+  }
+});
+
+it('throw with empty source map', function () {
+  const { full, inline } = createStackTraces(createEmptySourceMap(), ['throw new Error("test");']);
+
+  for (const stack of [full, inline]) {
+    expect(stack[0]).toBe('Error: test');
+    expect(stack[1]).toMatch(
+      /^    at Object\.<anonymous>\.exports\.test \((?:.*[/\\])?\.generated-\d+(?:-inline)?\.js:1:\d+\)$/,
+    );
+  }
+});
+
+it('throw with source map with gap', function () {
+  const { full, inline } = createStackTraces(createSourceMapWithGap(), [
+    'throw new Error("test");',
+  ]);
+
+  for (const stack of [full, inline]) {
+    expect(stack[0]).toBe('Error: test');
+    expect(stack[1]).toMatch(
+      /^    at Object\.<anonymous>\.exports\.test \((?:.*[/\\])?\.generated-\d+(?:-inline)?\.js:1:\d+\)$/,
+    );
+  }
+});
+
+it('finds the last sourceMappingURL', function () {
+  const { full, inline } = createStackTraces(createMultiLineSourceMapWithSourcesContent(), [
+    '//# sourceMappingURL=missing.map.js', // NB: createStackTraces adds another source mapping.
+    'throw new Error("test");',
+  ]);
+
+  for (const stack of [full, inline]) {
+    expect(stack[0]).toBe('Error: test');
+    expect(stack[1]).toMatch(
+      /^    at Object\.<anonymous>\.exports\.test \((?:.*[/\\])?original\.js:1002:5\)$/,
+    );
+  }
+});
+
+it('maps original name from source', function () {
+  const sourceMap = createEmptySourceMap();
+  sourceMap.addMapping({
+    generated: { line: 2, column: 8 },
+    original: { line: 1000, column: 10 },
+    source: '.original2.js',
+  });
+  sourceMap.addMapping({
+    generated: { line: 4, column: 0 },
+    original: { line: 1002, column: 1 },
+    source: '.original2.js',
+    name: 'myOriginalName',
+  });
+  const { full, inline } = createStackTraces(sourceMap, [
+    'function foo() {',
+    '  throw new Error("test");',
+    '}',
+    'foo();',
+  ]);
+
+  for (const stack of [full, inline]) {
+    expect(stack[0]).toBe('Error: test');
+    expect(stack[1]).toMatch(/^    at myOriginalName \((?:.*[/\\])?\.original2.js:1000:11\)$/);
+    expect(stack[2]).toMatch(
+      /^    at Object\.<anonymous>\.exports\.test \((?:.*[/\\])?\.original2.js:1002:2\)$/,
+    );
+  }
+});
+
+/* The following test duplicates some of the code in
+ * `createStackTraces` but appends a charset to the
+ * source mapping url.
+ */
+it('finds source maps with charset specified', function () {
+  const sourceMap = createMultiLineSourceMap();
+
+  const file = `./.generated-${counter}.js`;
+  fs.writeFileSync(
+    path.join(__dirname, file),
+    'exports.test = function() {' +
+      'throw new Error("test");' +
+      '};//@ sourceMappingURL=data:application/json;charset=utf8;base64,' +
+      Buffer.from(sourceMap.toString()).toString('base64'),
+  );
+  try {
+    require(file).test();
+  } catch (e) {
+    const stack = e.stack.split(/\r\n|\n/);
+    expect(stack[0]).toBe('Error: test');
+    expect(stack[1]).toMatch(
+      /^    at Object\.<anonymous>\.exports\.test \((?:.*[/\\])?line1\.js:1001:101\)$/,
+    );
+  }
+  fs.unlinkSync(path.join(__dirname, file));
+});
+
+/* The following test duplicates some of the code in
+ * `createStackTraces` but appends some code and a
+ * comment to the source mapping url.
+ */
+it('allows code/comments after sourceMappingURL', function () {
+  const sourceMap = createMultiLineSourceMap();
+  const file = `./.generated-${counter}.js`;
+  fs.writeFileSync(
+    path.join(__dirname, file),
+    'exports.test = function() {' +
+      'throw new Error("test");' +
+      '};//# sourceMappingURL=data:application/json;base64,' +
+      Buffer.from(sourceMap.toString()).toString('base64') +
+      '\n// Some comment below the sourceMappingURL\nvar foo = 0;',
+  );
+  try {
+    require(file).test();
+  } catch (e) {
+    const stack = e.stack.split(/\r\n|\n/);
+    expect(stack[0]).toBe('Error: test');
+    expect(stack[1]).toMatch(
+      /^    at Object\.<anonymous>\.exports\.test \((?:.*[/\\])?line1\.js:1001:101\)$/,
+    );
+  }
+  fs.unlinkSync(path.join(__dirname, file));
+});
+
+function createEmptySourceMap(): SourceMapGenerator {
+  return new SourceMapGenerator({
+    file: `.generated-${counter}.js`,
+    sourceRoot: '.',
+  });
+}
+
+function createSourceMapWithGap(): SourceMapGenerator {
+  const sourceMap = createEmptySourceMap();
+  sourceMap.addMapping({
+    generated: { line: 100, column: 0 },
+    original: { line: 100, column: 0 },
+    source: '.original.js',
+  });
+  return sourceMap;
+}
+
+function createMultiLineSourceMap(): SourceMapGenerator {
+  const sourceMap = createEmptySourceMap();
+  for (let i = 1; i <= 100; i++) {
+    sourceMap.addMapping({
+      generated: { line: i, column: 0 },
+      original: { line: 1000 + i, column: 99 + i },
+      source: 'line' + i + '.js',
+    });
+  }
+  return sourceMap;
+}
+
+function createMultiLineSourceMapWithSourcesContent(): SourceMapGenerator {
+  const sourceMap = createEmptySourceMap();
+  let original = new Array(1001).join('\n');
+  for (let i = 1; i <= 100; i++) {
+    sourceMap.addMapping({
+      generated: { line: i, column: 0 },
+      original: { line: 1000 + i, column: 4 },
+      source: 'original.js',
+    });
+    original += '    line ' + i + '\n';
+  }
+  sourceMap.setSourceContent('original.js', original);
+  return sourceMap;
+}
+
+function createStackTraces(
+  sourceMap: SourceMapSupport,
+  source: string[],
+): { full: string[]; inline: string[] } {
+  // Check once with a separate source map
+  fs.writeFileSync(`${__dirname}/.generated-${counter}.js.map`, sourceMap.toString());
+  fs.writeFileSync(
+    `${__dirname}/.generated-${counter}.js`,
+    'exports.test = function() {' +
+      source.join('\n') +
+      `};//@ sourceMappingURL=.generated-${counter}.js.map`,
+  );
+  const response = { full: null, inline: null };
+  try {
+    require(`./.generated-${counter}`).test();
+  } catch (e) {
+    response.full = e.stack.split(/\r\n|\n/);
+  }
+
+  fs.unlinkSync(`${__dirname}/.generated-${counter}.js`);
+  fs.unlinkSync(`${__dirname}/.generated-${counter}.js.map`);
+  // Check again with an inline source map (in a data URL)
+  fs.writeFileSync(
+    `${__dirname}/.generated-${counter}-inline.js`,
+    'exports.test = function() {' +
+      source.join('\n') +
+      '};//@ sourceMappingURL=data:application/json;base64,' +
+      Buffer.from(sourceMap.toString()).toString('base64'),
+  );
+  try {
+    require(`./.generated-${counter}-inline`).test();
+  } catch (e) {
+    response.inline = e.stack.split(/\r\n|\n/);
+  }
+  fs.unlinkSync(`${__dirname}/.generated-${counter}-inline.js`);
+
+  return response;
+}

--- a/server/cli-commands/package.json
+++ b/server/cli-commands/package.json
@@ -3,7 +3,7 @@
   "version": "1.5.4",
   "description": "The server CLI",
   "dependencies": {
-    "@ulixee/commons": "1.5.8",
+    "@ulixee/commons": "1.5.9",
     "@ulixee/server": "1.5.4",
     "yargs-parser": "^20.2.9"
   },

--- a/server/main/package.json
+++ b/server/main/package.json
@@ -7,7 +7,7 @@
     "start:alive": "node -r @ulixee/apps-chromealive-core/register ../cli-commands/bin/start.js"
   },
   "dependencies": {
-    "@ulixee/commons": "1.5.8",
+    "@ulixee/commons": "1.5.9",
     "@ulixee/hero-core": "1.5.4",
     "@ulixee/databox-core": "1.5.4",
     "@ulixee/hero-plugin-utils": "1.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3202,15 +3202,6 @@
     progress "^2.0.3"
     tar "^6.1.0"
 
-"@ulixee/commons@1.5.5":
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/@ulixee/commons/-/commons-1.5.5.tgz#65c471d0f705816cf42ec9c695e2028bfa86558b"
-  integrity sha512-iSMgDYVERbXfsFhhGgrMH3oTA/R3tnc3Z+6pRIIqtFDGJqc/m0ManpWWhBly0iBSrEyy2lbKETk3cFu7WnaQzw==
-  dependencies:
-    https-proxy-agent "^5.0.0"
-    source-map-support "^0.5.19"
-    uuid "^8.3.2"
-
 "@vue/babel-helper-vue-jsx-merge-props@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@vue/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-1.2.1.tgz#31624a7a505fb14da1d58023725a4c5f270e6a81"
@@ -14905,6 +14896,11 @@ source-map-js@^0.6.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
   integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
 
+source-map-js@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.1.tgz#a1741c131e3c77d048252adfa24e23b908670caf"
+  integrity sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==
+
 source-map-loader@^0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-0.2.4.tgz#c18b0dc6e23bf66f6792437557c569a11e072271"
@@ -16965,11 +16961,6 @@ ws@^6.0.0, ws@^6.2.1:
   integrity sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==
   dependencies:
     async-limiter "~1.0.0"
-
-ws@^7.4.4:
-  version "7.5.6"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.6.tgz#e59fc509fb15ddfb65487ee9765c5a51dec5fe7b"
-  integrity sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==
 
 ws@^7.4.6:
   version "7.5.3"


### PR DESCRIPTION
This PR optimizes SourceMap loading by forking the source-map-support library. All browser support is removed, and it caches way more aggressively. This step was needed so we could re-use the SourceMap lookups in order to be able to load SourceCode for typescript code, which is a feature we are using to give "Circuits" names