### PR TITLE
feat(herobox): add herobox

### DIFF
--- a/commons/package.json
+++ b/commons/package.json
@@ -8,8 +8,6 @@
     "source-map-js": "^1.0.1"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^5.4.1",
-    "@ulixee/default-browser-emulator": "1.5.4",
-    "@ulixee/hero-puppet": "1.5.4"
+    "@types/better-sqlite3": "^5.4.1"
   }
 }

--- a/commons/test/TypeSerializer.test.ts
+++ b/commons/test/TypeSerializer.test.ts
@@ -1,4 +1,7 @@
+// suppressing this error since including it requires puppet to be published
+// eslint-disable-next-line import/no-extraneous-dependencies
 import Puppet from '@ulixee/hero-puppet';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import BrowserEmulator from '@ulixee/default-browser-emulator';
 import TypeSerializer, { stringifiedTypeSerializerClass } from '../lib/TypeSerializer';
 import { CanceledPromiseError } from '../interfaces/IPendingWaitEvent';

--- a/herobox/examples/.ulixee/config.json
+++ b/herobox/examples/.ulixee/config.json
@@ -1,0 +1,3 @@
+{
+  "serverHost": "localhost:1337"
+}

--- a/herobox/examples/datasets.ts
+++ b/herobox/examples/datasets.ts
@@ -1,0 +1,25 @@
+import Herobox from '@ulixee/herobox';
+
+export default new Herobox(async herobox => {
+  const { input, output, hero } = herobox;
+  input.url ??= 'https://ulixee.org';
+  await hero.goto('https://ulixee.org');
+
+  const { document } = hero;
+  // step 1 - look in dom
+  const datasets = await document.querySelectorAll('.datasets .title');
+
+  output.datasets = [];
+  const length = await datasets.length;
+  for (let i = 0; i < length; i += 1) {
+    const dataset = await document.querySelectorAll('.datasets .title')[i];
+    const title = await dataset.textContent;
+    await hero.click(dataset);
+    await hero.waitForLocation('change');
+    const frozenTab = await hero.detach(hero.activeTab);
+    const cost = await frozenTab.document.querySelector('.cost .large-text').innerText;
+    output.push({ cost, title });
+    await hero.goBack();
+    await hero.waitForLocation('change');
+  }
+});

--- a/herobox/examples/demo.ts
+++ b/herobox/examples/demo.ts
@@ -1,0 +1,9 @@
+import Herobox from '../index';
+
+export default new Herobox(async ({ hero }) => {
+  await hero.goto('https://www.kayak.com');
+  await hero.waitForPaintingStable();
+
+  await hero.goto('https://www.kayak.com/flights');
+  await hero.waitForPaintingStable();
+});

--- a/herobox/examples/example.org.ts
+++ b/herobox/examples/example.org.ts
@@ -1,0 +1,16 @@
+import Herobox from '@ulixee/herobox';
+
+// configure input.url by running as node example.org.js --input.url="https://ulixee.org"
+
+export default new Herobox(async herobox => {
+  const { input, output, hero } = herobox;
+  input.url ??= 'https://example.org';
+
+  await hero.goto(input.url);
+  const title = await hero.document.title;
+
+  output.title = title;
+  output.body = await hero.document.body.textContent;
+  console.log(`LOADED ${input.url}: ${title}`);
+  await hero.close();
+});

--- a/herobox/examples/kayak.ts
+++ b/herobox/examples/kayak.ts
@@ -1,0 +1,34 @@
+import Hero from '@ulixee/hero';
+import Herobox from '@ulixee/herobox';
+import { KeyboardKey } from '@ulixee/hero-interfaces/IKeyboardLayoutUS';
+
+export default new Herobox(async databox => {
+  const { input, output, hero } = databox;
+  input.url ??= 'https://www.kakak.com';
+
+  await hero.goto(input.url);
+  await hero.waitForPaintingStable();
+  let url = await hero.url;
+
+  while (!url.includes('kayak.com')) {
+    await hero.waitForLocation('change');
+    await hero.waitForPaintingStable();
+    url = await hero.url;
+  }
+
+  const { document } = hero;
+  url = await hero.url;
+  if (!url.includes('/flights')) {
+    await document.querySelector("a[href='/flights']").$click();
+    await hero.waitForLocation('change');
+    await hero.waitForPaintingStable();
+  }
+
+  const form = await document.querySelector(
+    '.Ui-Searchforms-Flights-Components-FlightSearchForm-container',
+  );
+  const origin = await form.querySelector('div[class$="origin"]');
+  await origin.$click();
+  await hero.type(KeyboardKey.Backspace, KeyboardKey.Backspace, KeyboardKey.Backspace);
+  await hero.type('San Francisco');
+});

--- a/herobox/examples/news.ycombinator.com-extract.ts
+++ b/herobox/examples/news.ycombinator.com-extract.ts
@@ -1,0 +1,50 @@
+import Herobox from '@ulixee/herobox';
+
+export default new Herobox(async ({ hero }) => {
+  await hero.goto('https://news.ycombinator.com/');
+  await hero.waitForPaintingStable();
+  await hero.document.querySelector('#hnmain').$extractLater('table');
+
+  const links = await hero.document.querySelectorAll('.subtext > a');
+
+  const lastStory = await links[(await links.length) - 1];
+
+  if (lastStory) {
+    await hero.click(lastStory);
+    await hero.waitForLocation('change');
+    await hero.waitForElement(hero.document.querySelector('textarea'));
+    await hero.click(hero.document.querySelector('textarea'));
+    await hero.type('Hackernews!');
+    // const comments = [...(await hero.document.querySelectorAll('.commtext'))];
+    // await hero.interact({
+    //   move: comments[comments.length - 1],
+    // });
+  }
+}).extract(async ({ output, collectedFragments }) => {
+  const stories = collectedFragments.get('table').querySelectorAll('.athing');
+  for (const story of await stories) {
+    const extraElem = await story.nextElementSibling;
+    output.push({});
+    const record = output[output.length - 1];
+
+    const titleElem = await story.querySelector('a.titlelink');
+
+    record.score = parseInt(
+      await extraElem.querySelector('.score').textContent.catch(() => '0'),
+      10,
+    );
+    record.id = await story.getAttribute('id');
+    record.age = await extraElem.querySelector('.age a').textContent;
+    record.subject = await titleElem.textContent;
+    const contributor = await extraElem.querySelector('.hnuser').textContent.catch(() => '');
+    record.contributor = { id: contributor, username: contributor };
+    const links = [...(await extraElem.querySelectorAll('.subtext > a'))];
+    const commentsLink = links[links.length - 1];
+    const commentText = await commentsLink.textContent;
+    record.commentCount = commentText.includes('comment')
+      ? parseInt(commentText.trim().match(/(\d+)\s/)[0], 10)
+      : 0;
+
+    record.url = await titleElem.getAttribute('href');
+  }
+});

--- a/herobox/examples/news.ycombinator.com.ts
+++ b/herobox/examples/news.ycombinator.com.ts
@@ -1,0 +1,52 @@
+import Herobox from '@ulixee/herobox';
+
+export default new Herobox(async ({ hero, output }) => {
+  await hero.goto('https://news.ycombinator.com/');
+  await hero.waitForPaintingStable();
+
+  const stories = await hero.document.querySelectorAll('.athing');
+  const records = output;
+  let lastStory;
+
+  for (const story of stories) {
+    const extraElem = await story.nextElementSibling;
+    records.push({});
+    const record = records[records.length - 1];
+
+    const titleElem = await story.querySelector('a.titlelink');
+
+    record.score = parseInt(
+      await extraElem.querySelector('.score').textContent.catch(() => '0'),
+      10,
+    );
+    record.id = await story.getAttribute('id');
+    record.age = await extraElem.querySelector('.age a').textContent;
+    record.title = await titleElem.textContent;
+    const contributor = await extraElem.querySelector('.hnuser').textContent.catch(() => '');
+    record.contributor = { id: contributor, username: contributor };
+
+    const links = [...(await extraElem.querySelectorAll('.subtext > a'))];
+    const commentsLink = links[links.length - 1];
+    const commentText = await commentsLink.textContent;
+    record.commentCount = commentText.includes('comment')
+      ? parseInt(commentText.trim().match(/(\d+)\s/)[0], 10)
+      : 0;
+
+    lastStory = commentsLink;
+    record.url = await titleElem.getAttribute('href');
+  }
+
+  if (lastStory) {
+    await hero.click(lastStory);
+    await hero.waitForLocation('change');
+    await hero.waitForElement(hero.document.querySelector('textarea'));
+    await hero.click(hero.document.querySelector('textarea'));
+    await hero.type('Hackernews!');
+    // const comments = [...(await hero.document.querySelectorAll('.commtext'))];
+    // await hero.interact({
+    //   move: comments[comments.length - 1],
+    // });
+  }
+
+  await hero.close();
+});

--- a/herobox/examples/pagestate.ts
+++ b/herobox/examples/pagestate.ts
@@ -1,0 +1,18 @@
+import Herobox from '../index';
+
+export default new Herobox(async herobox => {
+  const { hero } = herobox;
+  await hero.goto('https://ulixee.org');
+  const state = await hero.waitForPageState({
+    // default: ({ loadFrom }) =>
+    //   loadFrom('@/pagestate/8f9ad51925801787abfde70013c7cb53/koL6ERf67__fkfwIy3RQc.json'),
+  });
+  //
+  // await hero.click(hero.document.querySelector('.search-form input'));
+  // await hero.type('flights');
+  // await hero.type(KeyboardKey.Enter);
+  //
+  // const page2 = await hero.waitForPageState({
+  //   "default": ({ loadFrom }) => loadFrom("@/pagestate/d92ae117998699589b5a4f321a26db42/dim_8KCb31DsGmLl3dIUl.json"),
+  // });
+});

--- a/herobox/examples/ulixee.org.ts
+++ b/herobox/examples/ulixee.org.ts
@@ -1,0 +1,24 @@
+import Herobox from '../index';
+
+export default new Herobox(async herobox => {
+  const { input, output, hero } = herobox;
+  input.url ??= 'https://ulixee.org';
+
+  await hero.goto('https://ulixee.org');
+
+  const { document } = hero;
+  await document.querySelector('h1').textContent;
+
+  // // step 1 - look in dom
+  // const datasets = await document.querySelectorAll('.datasets .title');
+  //
+  // // step 2 - start collecting datasets
+  // output.datasets = [];
+  // for (const dataset of datasets) {
+  //   output.datasets.push(await dataset.textContent);
+  // }
+  //
+  // // step 3 - look at the first one
+  // await hero.click(datasets[0]);
+  // await hero.waitForLocation('change');
+});

--- a/herobox/index.ts
+++ b/herobox/index.ts
@@ -1,0 +1,4 @@
+import '@ulixee/commons/lib/SourceMapSupport';
+import PackagedHerobox from './lib/PackagedHerobox';
+
+export default PackagedHerobox;

--- a/herobox/interfaces/IExtractParams.ts
+++ b/herobox/interfaces/IExtractParams.ts
@@ -1,0 +1,10 @@
+import RunningHerobox from '../lib/RunningHerobox';
+import Resource from '@ulixee/hero/lib/Resource';
+import Hero from '@ulixee/hero';
+
+export default interface IExtractParams {
+  input: RunningHerobox['input'];
+  output: RunningHerobox['output'];
+  collectedFragments: { names: string[]; get: Hero['getFragment'] };
+  collectedResources: { names: string[]; get(name: string): Resource };
+}

--- a/herobox/lib/PackagedHerobox.ts
+++ b/herobox/lib/PackagedHerobox.ts
@@ -1,0 +1,62 @@
+import IComponents from '@ulixee/databox/interfaces/IComponents';
+import Resource from '@ulixee/hero/lib/Resource';
+import PackagedDatabox from '@ulixee/databox';
+import RunningHerobox from './RunningHerobox';
+import IExtractParams from '../interfaces/IExtractParams';
+
+type IScriptFn = (herobox: RunningHerobox) => void | Promise<void>;
+type IExtractFn = (extract: IExtractParams) => void | Promise<void>;
+
+export default class PackagedHerobox extends PackagedDatabox {
+  #interactFn: IScriptFn;
+  #extractFn: IExtractFn;
+
+  constructor(scriptFn: IScriptFn, otherComponents: Omit<IComponents, 'scriptFn'> = {}) {
+    super(scriptFn, otherComponents);
+    this.#interactFn = scriptFn;
+  }
+
+  public extract(extractFn: IExtractFn): PackagedHerobox {
+    this.#extractFn = extractFn;
+    return this;
+  }
+
+  protected async runScript(): Promise<void> {
+    const herobox = this.runningDatabox as RunningHerobox;
+    const extractSessionId =
+      (herobox.queryOptions as any).extractSessionId ?? process.env.HERO_EXTRACT_SESSION_ID;
+
+    if (!extractSessionId) {
+      await this.#interactFn(herobox);
+    }
+    if (this.#extractFn) {
+      const { hero } = herobox;
+      const sessionId = extractSessionId ?? (await hero.sessionId);
+      const fragments = await hero.importFragments(sessionId);
+      const fragmentsByName: IExtractParams['collectedFragments'] = {
+        names: fragments.map(x => x.name),
+        get: hero.getFragment,
+      };
+      const resourcesByName: IExtractParams['collectedResources'] = {
+        names: [],
+        get(): Resource {
+          return null;
+        },
+      };
+
+      for (const fragment of fragments) {
+        fragmentsByName[fragment.name] = fragment;
+      }
+      await this.#extractFn({
+        input: herobox.input,
+        output: herobox.output,
+        collectedFragments: fragmentsByName,
+        collectedResources: resourcesByName,
+      });
+    }
+  }
+
+  protected createRunningDataboxFn(connectionManager, databoxOptions): Promise<RunningHerobox> {
+    return Promise.resolve(new RunningHerobox(connectionManager, databoxOptions));
+  }
+}

--- a/herobox/lib/RunningHerobox.ts
+++ b/herobox/lib/RunningHerobox.ts
@@ -1,0 +1,33 @@
+import { RunningDatabox } from '@ulixee/databox';
+import Hero, { IHeroCreateOptions } from '@ulixee/hero';
+import IDataboxRunOptions from '@ulixee/databox-interfaces/IDataboxRunOptions';
+import ConnectionManager from '@ulixee/databox/lib/ConnectionManager';
+
+export default class RunningHerobox extends RunningDatabox {
+  public readonly hero: Hero;
+
+  constructor(connectionManager: ConnectionManager, queryOptions: IDataboxRunOptions) {
+    super(connectionManager, queryOptions);
+
+    const heroOptions: IHeroCreateOptions = {};
+    for (const [key, value] of Object.entries(queryOptions)) {
+      heroOptions[key] = value;
+    }
+
+    heroOptions.connectionToCore = {
+      host: this.host,
+    };
+    heroOptions.externalIds ??= {};
+    heroOptions.externalIds.databoxSessionId = this.sessionId;
+
+    const hero = new Hero(heroOptions);
+    this.hero = hero;
+
+    void hero.on('command', (command, commandId) => {
+      this.lastExternalId = commandId;
+    });
+
+    this.beforeClose = () => hero.close();
+    this.on('error', () => hero.close());
+  }
+}

--- a/herobox/package.json
+++ b/herobox/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@ulixee/herobox",
+  "version": "1.5.4",
+  "description": "A Databox format for Hero",
+  "scripts": {},
+  "dependencies": {
+    "@ulixee/commons": "1.5.9",
+    "@ulixee/databox": "1.5.4",
+    "@ulixee/databox-interfaces": "1.5.4",
+    "@ulixee/hero": "1.5.4",
+    "@ulixee/hero-interfaces": "1.5.4"
+  },
+  "devDependencies": {
+    "@ulixee/databox-testing": "1.5.4"
+  }
+}

--- a/herobox/test/basic.test.ts
+++ b/herobox/test/basic.test.ts
@@ -1,0 +1,178 @@
+import { ConnectionToCore as ConnectionToHeroCore } from '@ulixee/hero';
+import ConnectionFactory from '@ulixee/hero/connections/ConnectionFactory';
+import ICoreRequestPayload from '@ulixee/databox-interfaces/ICoreRequestPayload';
+import ICoreResponsePayload from '@ulixee/databox-interfaces/ICoreResponsePayload';
+import { Helpers } from '@ulixee/databox-testing';
+import ConnectionToDataboxCore from '@ulixee/databox/connections/ConnectionToCore';
+import Herobox from '../index';
+
+afterAll(Helpers.afterAll);
+
+class MockedConnectionToDataboxCore extends ConnectionToDataboxCore {
+  public readonly outgoing = jest.fn(
+    async ({ command }: ICoreRequestPayload): Promise<ICoreResponsePayload> => {
+      if (command === 'Core.createSession') {
+        return {
+          data: { sessionId: 'session-id' },
+        };
+      }
+    },
+  );
+
+  async internalSendRequest(payload: ICoreRequestPayload): Promise<void> {
+    const response = await this.outgoing(payload);
+    this.onMessage({
+      responseId: payload.messageId,
+      data: response?.data ?? {},
+      ...(response ?? {}),
+    });
+  }
+
+  protected createConnection = () => Promise.resolve(null);
+  protected destroyConnection = () => Promise.resolve(null);
+}
+
+class MockedConnectionToHeroCore extends ConnectionToHeroCore {
+  public readonly outgoing = jest.fn(
+    async ({ command }: ICoreRequestPayload): Promise<ICoreResponsePayload> => {
+      if (command === 'Core.createSession') {
+        return {
+          data: { sessionId: 'session-id' },
+        };
+      }
+      if (command === 'Session.loadAllFragments') {
+        return {
+          data: [],
+        };
+      }
+    },
+  );
+
+  async internalSendRequest(payload: ICoreRequestPayload): Promise<void> {
+    const response = await this.outgoing(payload);
+    this.onMessage({
+      responseId: payload.messageId,
+      data: response?.data ?? {},
+      ...(response ?? {}),
+    });
+  }
+
+  protected createConnection = () => Promise.resolve(null);
+  protected destroyConnection = () => Promise.resolve(null);
+}
+
+describe('basic Herobox tests', () => {
+  it('waits until run method is explicitly called', async () => {
+    process.env.DATABOX_RUN_LATER = 'true';
+    let lastExternalId = 0;
+    const connectionToDataboxCore = new MockedConnectionToDataboxCore();
+    const connectionToHeroCore = new MockedConnectionToHeroCore();
+    jest
+      .spyOn(ConnectionFactory, 'createConnection')
+      .mockImplementationOnce(() => connectionToHeroCore);
+    const packagedDatabox = new Herobox(async herobox => {
+      const hero = herobox.hero;
+      await hero.goto('https://news.ycombinator.org');
+      await hero.close();
+      lastExternalId = herobox.lastExternalId;
+    });
+    await packagedDatabox.run({ connectionToCore: connectionToDataboxCore });
+    expect(lastExternalId).toBe(2);
+
+    const outgoingDataboxCommands = connectionToDataboxCore.outgoing.mock.calls;
+    expect(outgoingDataboxCommands.map(c => c[0].command)).toMatchObject([
+      'Core.connect',
+      'Core.createSession',
+      'Session.close',
+    ]);
+
+    const outgoingHeroCommands = connectionToHeroCore.outgoing.mock.calls;
+    expect(outgoingHeroCommands.map(c => c[0].command)).toMatchObject([
+      'Core.connect',
+      'Core.createSession',
+      'Tab.goto',
+      'Session.close',
+      'Core.disconnect',
+    ]);
+  });
+
+  it('should call close on hero automatically', async () => {
+    process.env.DATABOX_RUN_LATER = 'true';
+    const connectionToDataboxCore = new MockedConnectionToDataboxCore();
+    const connectionToHeroCore = new MockedConnectionToHeroCore();
+    jest
+      .spyOn(ConnectionFactory, 'createConnection')
+      .mockImplementationOnce(() => connectionToHeroCore);
+    const packagedDatabox = new Herobox(async herobox => {
+      const hero = herobox.hero;
+      await hero.goto('https://news.ycombinator.org');
+    });
+    await packagedDatabox.run({ connectionToCore: connectionToDataboxCore });
+
+    const outgoingHeroCommands = connectionToHeroCore.outgoing.mock.calls;
+    expect(outgoingHeroCommands.map(c => c[0].command)).toMatchObject([
+      'Core.connect',
+      'Core.createSession',
+      'Tab.goto',
+      'Session.close',
+      'Core.disconnect',
+    ]);
+  });
+
+  it('should emit close hero on error', async () => {
+    process.env.DATABOX_RUN_LATER = 'true';
+    const connectionToDataboxCore = new MockedConnectionToDataboxCore();
+    const connectionToHeroCore = new MockedConnectionToHeroCore();
+    jest
+      .spyOn(ConnectionFactory, 'createConnection')
+      .mockImplementationOnce(() => connectionToHeroCore);
+    const packagedDatabox = new Herobox(async herobox => {
+      const hero = herobox.hero;
+      await hero.goto('https://news.ycombinator.org').then(() => {
+        throw new Error('test');
+      });
+
+      await hero.interact('click');
+    });
+
+    await expect(
+      packagedDatabox.run({ connectionToCore: connectionToDataboxCore }),
+    ).rejects.toThrowError();
+
+    const outgoingHeroCommands = connectionToHeroCore.outgoing.mock.calls;
+    expect(outgoingHeroCommands.map(c => c[0].command)).toMatchObject([
+      'Core.connect',
+      'Core.createSession',
+      'Tab.goto',
+      'Session.close',
+      'Core.disconnect',
+    ]);
+  });
+
+  it('should be able to bypass the interaction step', async () => {
+    process.env.DATABOX_RUN_LATER = 'true';
+    process.env.HERO_EXTRACT_SESSION_ID = '1';
+    const connectionToDataboxCore = new MockedConnectionToDataboxCore();
+    const connectionToHeroCore = new MockedConnectionToHeroCore();
+    jest
+      .spyOn(ConnectionFactory, 'createConnection')
+      .mockImplementationOnce(() => connectionToHeroCore);
+
+    const interactFn = jest.fn();
+    const extractFn = jest.fn();
+    const packagedDatabox = new Herobox(interactFn).extract(extractFn);
+
+    await packagedDatabox.run({ connectionToCore: connectionToDataboxCore });
+    expect(interactFn).not.toHaveBeenCalled();
+    expect(extractFn).toHaveBeenCalledTimes(1);
+
+    const outgoingHeroCommands = connectionToHeroCore.outgoing.mock.calls;
+    expect(outgoingHeroCommands.map(c => c[0].command)).toMatchObject([
+      'Core.connect',
+      'Core.createSession',
+      'Session.loadAllFragments',
+      'Session.close',
+      'Core.disconnect',
+    ]);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
       "server/*",
       "hero/build/*",
       "hero/build/plugins/*",
-      "databox/build/*"
+      "databox/build/*",
+      "herobox"
     ],
     "nohoist": [
       "**/babel-loader",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     "preserveSymlinks": false,
     "experimentalDecorators": true
   },
-  "include": ["server", "apps", "commons", "./*.js", "./*.json", ".eslintrc.js"],
+  "include": ["server", "apps", "commons", "herobox", "./*.js", "./*.json", ".eslintrc.js"],
   "exclude": [
     "**/tsconfig*.json",
     "build/**/*",


### PR DESCRIPTION
This PR moves the hero/databox integration into a project that lives directly in Ulixee called "herobox".

Heroboxes automatically initialized a Hero instance and pass into the databox as part of a RunningHerobox (it can be destructured).

Heroboxes also have a separate extract phase that can be specified in the "extract" function of the Herobox. If you want to ONLY run an extraction phase from a specific session, you can pass --extract-session-id=EKizO6pBYilf9VI-UsWAL as a cli variable to the databox. The extract phase only gives access to collected fragments and resources from that prior session.