### PR TITLE
fix(timeline): differentiate nav start vs receive

### DIFF
--- a/apps/chromealive-ui/src/assets/icons/navigate.svg
+++ b/apps/chromealive-ui/src/assets/icons/navigate.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 10 10" >
+    <g><path d="M9,1L1,4h5v5L9,1z"/></g>
+</svg>

--- a/apps/chromealive-ui/src/pages/timeline/views/Live.vue
+++ b/apps/chromealive-ui/src/pages/timeline/views/Live.vue
@@ -95,6 +95,7 @@ import Timeline, { ITimelineHoverEvent, ITimelineTick } from '@/components/Timel
 import TimelineHandle from '@/components/TimelineHandle.vue';
 import TimelineHover from '@/components/TimelineHover.vue';
 import Menu from '@/components/Menu.vue';
+import { LoadStatus } from '@ulixee/hero-interfaces/Location';
 
 type IStartLocation = 'currentLocation' | 'sessionStart';
 
@@ -433,8 +434,17 @@ export default Vue.defineComponent({
         timelineTicks.push({
           id: url.navigationId,
           offsetPercent: url.offsetPercent,
-          class: 'url',
+          class: 'urlrequest',
         });
+        for (const status of url.loadStatusOffsets) {
+          if (status.loadStatus === LoadStatus.HttpResponded) {
+            timelineTicks.push({
+              id: url.navigationId,
+              offsetPercent: status.offsetPercent,
+              class: 'url',
+            });
+          }
+        }
       }
 
       let unresolvedPageStateTick: ITimelineTick;
@@ -669,6 +679,23 @@ export default Vue.defineComponent({
       background-size: contain;
       background-repeat: no-repeat;
     }
+    .bar .tick.urlrequest .marker {
+      width: 12px;
+      height: 12px;
+      left: -7px;
+      top: 15px;
+      opacity: 0.9;
+      z-index: 2;
+      border: 0 none;
+      display: inline-block;
+      -webkit-backface-visibility: hidden;
+      backface-visibility: hidden;
+      background-size: contain;
+      background-repeat: no-repeat;
+      background-image: url('~@/assets/icons/navigate.svg');
+      background-color: transparent;
+    }
+
     &:hover {
       .bar .tick.pagestate .marker {
         z-index: 0;


### PR DESCRIPTION
Added a start and end marker on the timeline for navigations - otherwise a script with multiple navigations is too hard to use the bar. This is a temporary UI, but wanted to try out having an initiated and http received marker.