### PR TITLE
feat: added typed input/output to databox + other improvements

### DIFF
--- a/databox/client/interfaces/IBasicInput.ts
+++ b/databox/client/interfaces/IBasicInput.ts
@@ -1,0 +1,3 @@
+export default interface IBasicInput {
+  [key: string]: any;
+}

--- a/databox/client/interfaces/IComponents.ts
+++ b/databox/client/interfaces/IComponents.ts
@@ -1,22 +1,33 @@
-import { IClientPluginClass } from '@ulixee/hero-interfaces/IClientPlugin';
-import { IPluginClass } from '@ulixee/hero-interfaces/IPlugin';
+import { IHeroCreateOptions } from '@ulixee/hero';
 import Runner from '../lib/Runner';
 import Extractor from '../lib/Extractor';
 
-export default interface IComponents {
-  run: IRunFn;
-  extract?: IExtractFn;
-  plugins?: IHeroPlugin[];
+export default interface IComponents<TInput, TOutput> {
+  defaults?: IDefaultsObj<TInput, TOutput>;
+  run: IRunFn<TInput, TOutput>;
+  extract?: IExtractFn<TInput, TOutput>;
   schema?: any;
 }
 
-export type IHeroPlugin = string | IClientPluginClass | { [name: string]: IPluginClass };
+export interface IDefaultsObj<TInput, TOutput> {
+  hero?: Partial<IHeroCreateOptions>;
+  input?: Partial<TInput>;
+  output?: Partial<TOutput>;
+}
 
-export type IRunFn = (databox: Runner) => void | Promise<void>;
-export type IExtractFn = (databox: Extractor) => void | Promise<void>;
+export type IRunFn<TInput, TOutput> = (databox: Runner<TInput, TOutput>) => void | Promise<void>;
+export type IExtractFn<TInput, TOutput> = (
+  databox: Extractor<TInput, TOutput>,
+) => void | Promise<void>;
 
-export type IExtractElementFn<T> = (element: Element, databox: Extractor) => T | Promise<T>;
-export type IExtractElementsFn<T> = (elements: Element[], databox: Extractor) => T | Promise<T>;
+export type IExtractElementFn<T, TInput = any, TOutput = any> = (
+  element: Element,
+  databox: Extractor<TInput, TOutput>,
+) => T | Promise<T>;
+export type IExtractElementsFn<T, TInput = any, TOutput = any> = (
+  elements: Element[],
+  databox: Extractor<TInput, TOutput>,
+) => T | Promise<T>;
 
 export interface IExtractElementOptions {
   name?: string;

--- a/databox/client/lib/CollectedElements.ts
+++ b/databox/client/lib/CollectedElements.ts
@@ -10,6 +10,7 @@ export default class CollectedElements {
   #collectedElementsByName = new Map<string, ICollectedElement[]>();
   readonly #coreSessionPromise: Promise<ICoreSession>;
   readonly #sessionIdPromise: Promise<string>;
+  readonly #rawObjectByElement: Map<Element, ICollectedElement> = new Map();
 
   constructor(coreSessionPromise: Promise<ICoreSession>, sessionIdPromise: Promise<string>) {
     this.#coreSessionPromise = coreSessionPromise;
@@ -25,7 +26,7 @@ export default class CollectedElements {
     );
   }
 
-  async getMeta(name: string): Promise<ICollectedElement[]> {
+  async getMetaObjects(name: string): Promise<ICollectedElement[]> {
     if (this.#collectedElementsByName.has(name)) return this.#collectedElementsByName.get(name);
     const [coreSession, sessionId] = await Promise.all([
       this.#coreSessionPromise,
@@ -36,16 +37,26 @@ export default class CollectedElements {
     return elements;
   }
 
+  findMetaObjectByElement(element: Element): ICollectedElement {
+    return this.#rawObjectByElement.get(element)  ;
+  }
+
   async get(name: string): Promise<Element> {
-    const collectedElements = await this.getMeta(name);
+    const collectedElements = await this.getMetaObjects(name);
     if (collectedElements.length === 0) return null;
-    return CollectedElements.parseIntoFrozenDom(collectedElements[0].outerHTML);
+    const element = CollectedElements.parseIntoFrozenDom(collectedElements[0].outerHTML);
+    this.#rawObjectByElement.set(element, collectedElements[0]);
+    return element;
   }
 
   async getAll(name: string): Promise<Element[]> {
-    const collectedElements = await this.getMeta(name);
+    const collectedElements = await this.getMetaObjects(name);
     if (collectedElements.length === 0) return null;
-    return collectedElements.map(x => CollectedElements.parseIntoFrozenDom(x.outerHTML));
+    return collectedElements.map(x => {
+      const element = CollectedElements.parseIntoFrozenDom(x.outerHTML);
+      this.#rawObjectByElement.set(element, collectedElements[0]);
+      return element;
+    });
   }
 
   public static parseIntoFrozenDom(outerHTML: string): Element {

--- a/databox/client/lib/DataboxPackage.ts
+++ b/databox/client/lib/DataboxPackage.ts
@@ -4,15 +4,16 @@ import UlixeeConfig from '@ulixee/commons/config';
 import readCommandLineArgs from './utils/readCommandLineArgs';
 import IComponents, { IRunFn } from '../interfaces/IComponents';
 import DataboxInternal from './DataboxInternal';
+import IBasicInput from '../interfaces/IBasicInput';
 
-export default class DataboxPackage implements IDataboxPackage {
-  #components: IComponents;
+export default class DataboxPackage<TInput = IBasicInput, TOutput = any> implements IDataboxPackage {
+  #components: IComponents<TInput, TOutput>;
 
-  constructor(components: IRunFn | IComponents) {
+  constructor(components: IRunFn<TInput, TOutput> | IComponents<TInput, TOutput>) {
     this.#components =
       typeof components === 'function'
         ? {
-            run: components as IRunFn,
+            run: components as IRunFn<TInput, TOutput>,
           }
         : { ...components };
     if (process.env.DATABOX_RUN_LATER) return;
@@ -30,8 +31,8 @@ export default class DataboxPackage implements IDataboxPackage {
     this.run(options).catch(() => null);
   }
 
-  public async run(options: IDataboxRunOptions = {}): Promise<void> {
-    const databoxInternal = new DataboxInternal(options, this.#components.plugins);
+  public async run(options: IDataboxRunOptions = {}): Promise<any> {
+    const databoxInternal = new DataboxInternal<TInput, TOutput>(options, this.#components.defaults);
     const shouldRunFull = !databoxInternal.sessionIdToExtract;
     try {
       if (shouldRunFull) {

--- a/databox/client/lib/DomExtender.ts
+++ b/databox/client/lib/DomExtender.ts
@@ -14,7 +14,7 @@ import {
 } from 'awaited-dom/base/interfaces/official';
 import { awaitedPathState, extendNodeLists, extendNodes } from '@ulixee/hero/lib/DomExtender';
 import { IExtractElementFn, IExtractElementOptions, IExtractElementsFn } from '../interfaces/IComponents';
-import { getDataboxInternalByCoreSession } from './DataboxInternal';
+import { getDataboxInternalByHero } from './DataboxInternal';
 import CollectedElements from './CollectedElements';
 
 interface IBaseExtendNode {
@@ -49,8 +49,8 @@ const NodeExtensionFns: Omit<IBaseExtendNode, ''> = {
     const coreFrame = await awaitedOptions.coreFrame;
     const collectedElements = await coreFrame.collectElement(options.name, awaitedPath.toJSON(), true);
     const frozenElement = CollectedElements.parseIntoFrozenDom(collectedElements[0].outerHTML);
-    const coreSession = coreFrame.coreTab.coreSession;
-    const databoxInternal = getDataboxInternalByCoreSession(coreSession);
+    const hero = coreFrame.coreTab.coreSession.hero;
+    const databoxInternal = getDataboxInternalByHero(hero);
     const response = databoxInternal.execExtractor(extractFn, frozenElement);
     return response as unknown as T;
   },
@@ -67,8 +67,8 @@ const NodeListExtensionFns: IBaseExtendNodeList = {
     const coreFrame = await awaitedOptions.coreFrame;
     const collectedElements = await coreFrame.collectElement(options.name, awaitedPath.toJSON(), true);
     const frozenElements = collectedElements.map(x => CollectedElements.parseIntoFrozenDom(x.outerHTML));
-    const coreSession = coreFrame.coreTab.coreSession;
-    const databoxInternal = getDataboxInternalByCoreSession(coreSession);
+    const hero = coreFrame.coreTab.coreSession.hero;
+    const databoxInternal = getDataboxInternalByHero(hero);
     const response = databoxInternal.execExtractor(extractFn, frozenElements);
     return response as unknown as T;
   },

--- a/databox/client/lib/Extractor.ts
+++ b/databox/client/lib/Extractor.ts
@@ -4,11 +4,11 @@ import CollectedElements from './CollectedElements';
 import CollectedResources from './CollectedResources';
 import CollectedSnippets from './CollectedSnippets';
 
-export default class Extractor extends TypedEventEmitter<{ close: void; error: Error }> {
-  readonly #databoxInternal: DataboxInternal;
+export default class Extractor<TInput, TOutput> extends TypedEventEmitter<{ close: void; error: Error }> {
+  readonly #databoxInternal: DataboxInternal<TInput, TOutput>;
   readonly #sessionIdPromise: Promise<string>;
 
-  constructor(databoxInternal: DataboxInternal) {
+  constructor(databoxInternal: DataboxInternal<TInput, TOutput>) {
     super();
     const { sessionIdToExtract, hero } = databoxInternal;
     this.#databoxInternal = databoxInternal;
@@ -27,15 +27,15 @@ export default class Extractor extends TypedEventEmitter<{ close: void; error: E
     return new CollectedResources(this.#databoxInternal.coreSessionPromise, this.#sessionIdPromise);
   }
 
-  public get action(): DataboxInternal['action'] {
+  public get action(): DataboxInternal<TInput, TOutput>['action'] {
     return this.#databoxInternal.action;
   }
 
-  public get input(): DataboxInternal['input'] {
-    return this.#databoxInternal.input;
+  public get input(): TInput {
+    return this.#databoxInternal.input as TInput;
   }
 
-  public get output(): DataboxInternal['output'] {
+  public get output(): TOutput {
     return this.#databoxInternal.output;
   }
 
@@ -43,11 +43,11 @@ export default class Extractor extends TypedEventEmitter<{ close: void; error: E
     this.#databoxInternal.output = value;
   }
 
-  public get sessionId(): DataboxInternal['sessionId'] {
+  public get sessionId(): DataboxInternal<TInput, TOutput>['sessionId'] {
     return this.#databoxInternal.sessionId;
   }
 
-  public get schema(): DataboxInternal['schema'] {
+  public get schema(): DataboxInternal<TInput, TOutput>['schema'] {
     return this.#databoxInternal.schema;
   }
 }

--- a/databox/client/lib/Runner.ts
+++ b/databox/client/lib/Runner.ts
@@ -2,10 +2,10 @@ import Hero from '@ulixee/hero';
 import { TypedEventEmitter } from '@ulixee/commons/lib/eventUtils';
 import DataboxInternal from './DataboxInternal';
 
-export default class Runner extends TypedEventEmitter<{ close: void; error: Error }> {
-  #databoxInternal: DataboxInternal;
+export default class Runner<TInput, TOutput> extends TypedEventEmitter<{ close: void; error: Error }> {
+  #databoxInternal: DataboxInternal<TInput, TOutput>;
 
-  constructor(databoxActive: DataboxInternal) {
+  constructor(databoxActive: DataboxInternal<TInput, TOutput>) {
     super();
     this.#databoxInternal = databoxActive;
   }
@@ -19,15 +19,15 @@ export default class Runner extends TypedEventEmitter<{ close: void; error: Erro
     return this.#databoxInternal.hero;
   }
 
-  public get action(): DataboxInternal['action'] {
+  public get action(): DataboxInternal<TInput, TOutput>['action'] {
     return this.#databoxInternal.action;
   }
 
-  public get input(): DataboxInternal['input'] {
-    return this.#databoxInternal.input;
+  public get input(): TInput {
+    return this.#databoxInternal.input as TInput;
   }
 
-  public get output(): DataboxInternal['output'] {
+  public get output(): TOutput {
     return this.#databoxInternal.output;
   }
 
@@ -35,11 +35,11 @@ export default class Runner extends TypedEventEmitter<{ close: void; error: Erro
     this.#databoxInternal.output = value;
   }
 
-  public get sessionId(): DataboxInternal['sessionId'] {
+  public get sessionId(): DataboxInternal<TInput, TOutput>['sessionId'] {
     return this.#databoxInternal.sessionId;
   }
 
-  public get schema(): DataboxInternal['schema'] {
+  public get schema(): DataboxInternal<TInput, TOutput>['schema'] {
     return this.#databoxInternal.schema;
   }
 }

--- a/databox/client/test/fullstack-elements.test.ts
+++ b/databox/client/test/fullstack-elements.test.ts
@@ -73,7 +73,7 @@ describe('basic Element tests', () => {
   });
 });
 
-async function openBrowser(path: string): Promise<[Hero, ICoreSession, DataboxInternal]> {
+async function openBrowser(path: string): Promise<[Hero, ICoreSession, DataboxInternal<any, any>]> {
   const databoxInternal = await Helpers.createFullstackDataboxInternal();
   const hero = databoxInternal.hero;
   const coreSession = await databoxInternal.coreSessionPromise;

--- a/databox/client/test/output.test.ts
+++ b/databox/client/test/output.test.ts
@@ -36,7 +36,7 @@ describe('basic output tests', () => {
     const connection = new MockedConnectionToHeroCore();
     jest.spyOn(ConnectionFactory, 'createConnection').mockImplementationOnce(() => connection);
 
-    const databoxInternal = new DataboxInternal({});
+    const databoxInternal = new DataboxInternal<any, any>({});
     databoxInternal.output.test = true;
     await databoxInternal.close();
 

--- a/databox/interfaces/IDataboxPackage.ts
+++ b/databox/interfaces/IDataboxPackage.ts
@@ -1,5 +1,5 @@
 import IDataboxRunOptions from './IDataboxRunOptions';
 
-export default interface IDataboxPackage {
-  run(options?: IDataboxRunOptions): Promise<void>
+export default interface IDataboxPackage<TInput = any, TOutput = any> {
+  run(options?: IDataboxRunOptions<TInput>): Promise<void>
 }

--- a/databox/interfaces/IDataboxRunOptions.ts
+++ b/databox/interfaces/IDataboxRunOptions.ts
@@ -1,11 +1,11 @@
 import { IHeroCreateOptions } from '@ulixee/hero';
 
-export default interface IDataboxRunOptions
+export default interface IDataboxRunOptions<TInput = any>
   extends Partial<
     Omit<ISessionCreateOptions, 'scriptInstanceMeta'>
   >, IHeroCreateOptions {
   action?: string;
-  input?: {};
+  input?: TInput;
   fields?: {};
 }
 

--- a/databox/testing/helpers.ts
+++ b/databox/testing/helpers.ts
@@ -50,7 +50,7 @@ export function onClose(closeFn: (() => Promise<any>) | (() => any), onlyCloseOn
   needsClosing.push({ close: closeFn, onlyCloseOnFinal });
 }
 
-class FullstackDataboxInternal extends DataboxInternal {
+class FullstackDataboxInternal extends DataboxInternal<any, any> {
   protected initializeHero(): void {
     const heroOptions: IHeroCreateOptions = {};
     for (const [key, value] of Object.entries(this.runOptions)) {


### PR DESCRIPTION
Renamed CollectedElements#getMeta → getMetaObjects. Seemed clearer, but I can revert this if you disagree.

Added CollectedElements#findMetaObjectByElement

Added optional typing to new Databox<IDataboxInput, IDataboxOutput>. Typing is now required for Runner and Extractor classes.

Added optional `defaults:{ hero, input, output }` object to Databox.

Refactored how DataboxInternal and DomExtenders are connected. WeakMap is still used, but now it connects DataboxInternal to the Hero instances instead of CoreSession. This allows for hero.use(plugin) to be used within Databoxes.

Removed the `plugins` object from Databox.