### PR TITLE
feat(chromealive): hero script

### DIFF
--- a/apps/chromealive-core/apis/DomStateApi.ts
+++ b/apps/chromealive-core/apis/DomStateApi.ts
@@ -1,5 +1,4 @@
 import { IDomStateApiStatics } from '@ulixee/apps-chromealive-interfaces/apis/IDomStateApi';
-import ChromeAliveCore from '../index';
 import DomStateManager from '../lib/DomStateManager';
 
 @IDomStateApiStatics
@@ -58,5 +57,5 @@ export default class DomStateApi {
 }
 
 function getDomStateManager(): DomStateManager {
-  return ChromeAliveCore.activeSessionObserver.domStateManager;
+  return null;
 }

--- a/apps/chromealive-core/apis/index.ts
+++ b/apps/chromealive-core/apis/index.ts
@@ -22,6 +22,7 @@ const ApiHandlers: IApiHandlerSpec = {
   'Session.resume': SessionApi.resume,
   'Session.step': SessionApi.step,
   'Session.getScreenshot': SessionApi.getScreenshot,
+  'Session.getScriptState': SessionApi.getScriptState,
 };
 
 export default ApiHandlers;

--- a/apps/chromealive-core/lib/DomStateManager.ts
+++ b/apps/chromealive-core/lib/DomStateManager.ts
@@ -437,7 +437,7 @@ export default class DomStateManager extends TypedEventEmitter<{
     const lastCommand = tab.session.commands.history[tab.session.commands.length - 2];
     let name = `after "${lastCommand.name}"`;
     if (lastCommand.callsite) {
-      const callsite = JSON.parse(lastCommand.callsite)[0];
+      const callsite = lastCommand.callsite[0];
       const sourceCode = SourceLoader.getSource(callsite);
       if (sourceCode?.code) {
         name = `after "${sourceCode.code.trim()}"`;

--- a/apps/chromealive-core/lib/SourceCodeTimeline.ts
+++ b/apps/chromealive-core/lib/SourceCodeTimeline.ts
@@ -1,0 +1,91 @@
+import { Session } from '@ulixee/hero-core';
+import { bindFunctions } from '@ulixee/commons/lib/utils';
+import SourceLoader from '@ulixee/commons/lib/SourceLoader';
+import ICommandMeta from '@ulixee/hero-interfaces/ICommandMeta';
+import { SourceMapSupport } from '@ulixee/commons/lib/SourceMapSupport';
+import { TypedEventEmitter } from '@ulixee/commons/lib/eventUtils';
+import ISourceCodeLocation from '@ulixee/commons/interfaces/ISourceCodeLocation';
+import EventSubscriber from '@ulixee/commons/lib/EventSubscriber';
+import ICommandUpdatedEvent from '@ulixee/apps-chromealive-interfaces/events/ICommandUpdatedEvent';
+import ISourceCodeUpdatedEvent from '@ulixee/apps-chromealive-interfaces/events/ISourceCodeUpdatedEvent';
+
+export default class SourceCodeTimeline extends TypedEventEmitter<{
+  source: ISourceCodeUpdatedEvent;
+  command: ICommandUpdatedEvent;
+}> {
+  private sourceFileLines: { [path: string]: string[] } = {};
+  private events = new EventSubscriber();
+  private commandsById: { [id: number]: ICommandUpdatedEvent } = {};
+
+  constructor(readonly heroSession: Session) {
+    super();
+    bindFunctions(this);
+    this.events.on(heroSession.commands, 'start', this.onCommandStart);
+    this.events.on(heroSession.commands, 'finish', this.onCommandFinished);
+  }
+
+  public getCurrentState(): {
+    commandsById: Record<number, ICommandUpdatedEvent>;
+    sourceFileLines: Record<string, string[]>;
+  } {
+    return {
+      commandsById: this.commandsById,
+      sourceFileLines: this.sourceFileLines,
+    };
+  }
+
+  public close(): void {
+    this.events.close();
+    this.commandsById = {};
+  }
+
+  public clearCache(): void {
+    for (const filename of Object.keys(this.sourceFileLines)) {
+      this.sourceFileLines[filename] = undefined;
+      SourceMapSupport.clearCache(filename);
+    }
+    this.commandsById = {};
+  }
+
+  private onCommandStart(command: ICommandMeta): void {
+    if (!command.callsite) return;
+    const originalSourcePosition = command.callsite.map(x =>
+      SourceMapSupport.getOriginalSourcePosition(x),
+    );
+    this.checkForSourceUpdates(originalSourcePosition);
+    this.commandsById[command.id] = {
+      command,
+      isComplete: false,
+      originalSourcePosition,
+    };
+    this.emit('command', this.commandsById[command.id]);
+  }
+
+  private onCommandFinished(command: ICommandMeta): void {
+    if (!command.callsite) return;
+    const originalSourcePosition = command.callsite.map(x =>
+      SourceMapSupport.getOriginalSourcePosition(x),
+    );
+    this.checkForSourceUpdates(originalSourcePosition);
+    this.commandsById[command.id] = {
+      command,
+      isComplete: true,
+      originalSourcePosition,
+    };
+    this.emit('command', this.commandsById[command.id]);
+  }
+
+  private checkForSourceUpdates(sourceLocations: ISourceCodeLocation[]): void {
+    for (const sourcePosition of sourceLocations) {
+      const { filename } = sourcePosition;
+      if (!this.sourceFileLines[filename]) {
+        this.sourceFileLines[filename] =
+          SourceLoader.getFileContents(filename, false)?.split(/\r?\n/) ?? [];
+        this.emit('source', {
+          filename,
+          lines: this.sourceFileLines[filename],
+        });
+      }
+    }
+  }
+}

--- a/apps/chromealive-interfaces/apis/ISessionApi.ts
+++ b/apps/chromealive-interfaces/apis/ISessionApi.ts
@@ -1,4 +1,5 @@
 import ISessionCreateOptions from '@ulixee/hero-interfaces/ISessionCreateOptions';
+import ICommandUpdatedEvent from '../events/ICommandUpdatedEvent';
 
 export interface ISessionResumeArgs extends IHeroSessionArgs {
   startLocation: ISessionCreateOptions['sessionResume']['startLocation'];
@@ -21,6 +22,10 @@ export default interface ISessionApi {
   ): {
     imageBase64: string;
   };
+  getScriptState(args?: IHeroSessionArgs): Promise<{
+    commandsById: Record<number, ICommandUpdatedEvent>;
+    sourceFileLines: Record<string, string[]>;
+  }>;
   quit(args: IHeroSessionArgs): Promise<void>;
   timetravel(
     args: IHeroSessionArgs & {

--- a/apps/chromealive-interfaces/apis/index.ts
+++ b/apps/chromealive-interfaces/apis/index.ts
@@ -9,6 +9,7 @@ export type IApiHandlerSpec = {
   'Session.resume': ISessionApi['resume'];
   'Session.step': ISessionApi['step'];
   'Session.getScreenshot': ISessionApi['getScreenshot'];
+  'Session.getScriptState': ISessionApi['getScriptState'];
   'App.boundsChanged': IAppApi['boundsChanged'];
   'App.ready': IAppApi['ready'];
   'App.focus': IAppApi['focus'];

--- a/apps/chromealive-interfaces/events/ICommandFocusedEvent.ts
+++ b/apps/chromealive-interfaces/events/ICommandFocusedEvent.ts
@@ -1,0 +1,3 @@
+export default interface ICommandFocusedEvent {
+  commandId: number;
+}

--- a/apps/chromealive-interfaces/events/ICommandUpdatedEvent.ts
+++ b/apps/chromealive-interfaces/events/ICommandUpdatedEvent.ts
@@ -1,0 +1,8 @@
+import ICommandMeta from '@ulixee/hero-interfaces/ICommandMeta';
+import type ISourceCodeLocation from '@ulixee/commons/interfaces/ISourceCodeLocation';
+
+export default interface ICommandUpdatedEvent {
+  command: ICommandMeta;
+  isComplete: boolean;
+  originalSourcePosition: ISourceCodeLocation[];
+}

--- a/apps/chromealive-interfaces/events/ISourceCodeUpdatedEvent.ts
+++ b/apps/chromealive-interfaces/events/ISourceCodeUpdatedEvent.ts
@@ -1,0 +1,4 @@
+export default interface ISourceCodeUpdatedEvent {
+ filename: string;
+ lines: string[];
+}

--- a/apps/chromealive-interfaces/events/index.ts
+++ b/apps/chromealive-interfaces/events/index.ts
@@ -3,6 +3,9 @@ import IHeroSessionActiveEvent from './IHeroSessionActiveEvent';
 import IDomStateUpdateEvent from './IDomStateUpdatedEvent';
 import IAppMoveEvent from './IAppMoveEvent';
 import IAppModeEvent from './IAppModeEvent';
+import ICommandUpdatedEvent from './ICommandUpdatedEvent';
+import ISourceCodeUpdatedEvent from './ISourceCodeUpdatedEvent';
+import ICommandFocusedEvent from './ICommandFocusedEvent';
 
 export default interface IChromeAliveEvents {
   'App.show': { onTop: boolean };
@@ -17,4 +20,7 @@ export default interface IChromeAliveEvents {
   'Session.active': IHeroSessionActiveEvent;
   'Databox.updated': IDataboxUpdatedEvent;
   'DomState.updated': IDomStateUpdateEvent;
+  'Command.updated': ICommandUpdatedEvent;
+  'Command.focused': ICommandFocusedEvent;
+  'SourceCode.updated': ISourceCodeUpdatedEvent;
 }

--- a/apps/chromealive-ui/src/pages/hero-script/index.ts
+++ b/apps/chromealive-ui/src/pages/hero-script/index.ts
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import App from './index.vue';
+
+createApp(App).mount('#app');

--- a/apps/chromealive-ui/src/pages/hero-script/index.vue
+++ b/apps/chromealive-ui/src/pages/hero-script/index.vue
@@ -1,0 +1,201 @@
+<template>
+  <div class="wrapper">
+    <h5>{{ activeFilename }}</h5>
+    <div
+      class="line"
+      v-for="(line, i) in activeFileLines"
+      :class="getClassesForLineIndex(i)"
+      :ref="
+        el => {
+          lineElemsByIdx[i + 1] = el;
+        }
+      "
+    >
+      <span class="line-number">{{ i + 1 }}.</span>
+      <pre class="code">{{ line }}</pre>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import * as Vue from 'vue';
+import Client from '@/api/Client';
+import ICommandUpdatedEvent from '@ulixee/apps-chromealive-interfaces/events/ICommandUpdatedEvent';
+import ICommandFocusedEvent from '@ulixee/apps-chromealive-interfaces/events/ICommandFocusedEvent';
+import ISourceCodeUpdatedEvent from '@ulixee/apps-chromealive-interfaces/events/ISourceCodeUpdatedEvent';
+
+export default Vue.defineComponent({
+  name: 'HeroScriptPanel',
+  components: {},
+  setup() {
+    return {
+      commandIdsByLineKey: {} as { [filename_line: string]: Set<number> },
+      lineElemsByIdx: Vue.reactive<{ [index: number]: HTMLElement }>({}),
+      focusedPositions: Vue.reactive<{ line: number; filename: string }[]>([]),
+      focusedCommandId: Vue.ref<number>(null),
+      scriptsByFilename: Vue.reactive<Record<string, ISourceCodeUpdatedEvent['lines']>>({}),
+      commandsById: Vue.reactive<{ [commandId: number]: ICommandUpdatedEvent }>({}),
+    };
+  },
+  watch: {
+    ['focusedPositions.0.line'](value) {
+      const firstLine = value;
+      if (!firstLine) return;
+      setTimeout(() => {
+        const $el = this.lineElemsByIdx[firstLine];
+        if ($el) $el.scrollIntoView({ block: 'center' });
+      });
+    },
+  },
+  computed: {
+    activeFileLines(): string[] {
+      const filename = this.activeFilename;
+      if (!filename) return [];
+      return this.scriptsByFilename[filename] ?? [];
+    },
+    activeFilename(): string {
+      return this.focusedPositions?.length ? this.focusedPositions[0].filename : null;
+    },
+  },
+  methods: {
+    getCommandsAtPositions(
+      positions: { line: number; filename: string }[],
+    ): ICommandUpdatedEvent[] {
+      const commands: ICommandUpdatedEvent[] = [];
+      for (const position of positions) {
+        const key = `${position.filename}_${position.line}`;
+        if (!this.commandIdsByLineKey[key]) continue;
+
+        for (const id of this.commandIdsByLineKey[key]) {
+          const command = this.commandsById[id];
+          if (command) commands.push(command);
+        }
+      }
+      return commands;
+    },
+    getClassesForLineIndex(index: number) {
+      if (!this.focusedPositions?.length) return;
+      const active = this.focusedPositions.some(x => x.line === index + 1);
+      const commandsAtLines = this.getCommandsAtPositions(this.focusedPositions);
+      const hasError = commandsAtLines.some(x => x.command.resultType?.includes('Error'));
+      return { active, error: hasError };
+    },
+    onCommandUpdated(message: ICommandUpdatedEvent) {
+      this.commandsById[message.command.id] = message;
+      for (const position of message.originalSourcePosition ?? []) {
+        const key = `${position.filename}_${position.line}`;
+        this.commandIdsByLineKey[key] ??= new Set();
+        this.commandIdsByLineKey[key].add(message.command.id);
+      }
+      if (!this.focusedCommandId && message.originalSourcePosition?.length) {
+        this.setFocusedPositions(message.originalSourcePosition);
+      }
+    },
+    onCommandFocused(message: ICommandFocusedEvent) {
+      this.focusedCommandId = message.commandId;
+      const position = this.commandsById[message.commandId]?.originalSourcePosition;
+      if (!position?.length) return;
+      this.setFocusedPositions(position);
+    },
+    onSourceCodeUpdated(message: ISourceCodeUpdatedEvent) {
+      this.scriptsByFilename[message.filename] = message.lines;
+      if (!this.focusedPositions.length) {
+        this.focusedPositions.push({ filename: message.filename, line: 1 });
+      }
+    },
+
+    onScriptStateResponse(message: {
+      commandsById: Record<number, ICommandUpdatedEvent>;
+      sourceFileLines: Record<string, string[]>;
+    }) {
+      for (const ev of Object.values(message.commandsById)) {
+        this.onCommandUpdated(ev);
+      }
+      for (const [filename, lines] of Object.entries(message.sourceFileLines)) {
+        this.onSourceCodeUpdated({ filename, lines })
+      }
+    },
+
+    // private functions
+
+    setFocusedPositions(positions: ICommandUpdatedEvent['originalSourcePosition']) {
+      positions ??= [];
+      this.focusedPositions.length = positions.length;
+      Object.assign(this.focusedPositions, positions);
+    },
+  },
+
+  mounted() {
+    Client.connect().catch(err => alert(String(err)));
+    Client.send('Session.getScriptState')
+      .then(this.onScriptStateResponse)
+      .catch(err => alert(String(err)));
+
+    Client.on('SourceCode.updated', this.onSourceCodeUpdated);
+    Client.on('Command.updated', this.onCommandUpdated);
+    Client.on('Command.focused', this.onCommandFocused);
+  },
+
+  beforeUnmount() {
+    Client.off('SourceCode.updated', this.onSourceCodeUpdatd);
+    Client.off('Command.updated', this.onCommandUpdated);
+    Client.off('Command.focused', this.onCommandFocused);
+  },
+});
+</script>
+
+<style lang="scss">
+@import '../../assets/style/common-mixins';
+@import '../../assets/style/resets';
+
+:root {
+  --toolbarBackgroundColor: #f5faff;
+  --buttonActiveBackgroundColor: rgba(176, 173, 173, 0.4);
+  --buttonHoverBackgroundColor: rgba(255, 255, 255, 0.08);
+}
+
+body {
+  height: 100vh;
+  margin: 0;
+  border-top: 0 none;
+  width: 100%;
+}
+
+.wrapper {
+  box-sizing: border-box;
+  background: white;
+  margin: 0;
+}
+h5 {
+  margin: 10px;
+}
+.line {
+  display: flex;
+  flex: 1;
+  flex-direction: row;
+  justify-content: end;
+  align-items: baseline;
+  &.active {
+    background: green;
+    color: white;
+  }
+  &.error {
+    background: yellow;
+  }
+  .line-number {
+    display: flex;
+    flex-grow: 0;
+    flex-basis: 30px;
+    line-height: 13px;
+    font-size: 12px;
+    color: #595959;
+  }
+  pre {
+    flex: 1;
+    margin: 1px 0;
+    font-family: system-ui;
+    font-size: 13px;
+    line-height: 13px;
+  }
+}
+</style>

--- a/apps/chromealive-ui/src/pages/toolbar/index.vue
+++ b/apps/chromealive-ui/src/pages/toolbar/index.vue
@@ -31,7 +31,7 @@
         <ChevronRightIcon class="arrow" />
       </li>
 
-      <li :class="{ focused: mode === 'timetravel' }">
+      <li :class="{ focused: mode === 'timetravel' }" @click.prevent="toggleTimetravel()">
         <img class="icon" src="/icons/timetravel.svg" />
         <div class="label">Timetravel</div>
         <div class="count">{{ timetravelEvents > 0 ? timetravelEvents : '' }}</div>
@@ -54,11 +54,13 @@ import humanizeBytes from '@/utils/humanizeBytes';
 enum Panel {
   domstate = 'domstate',
   output = 'output',
+  timetravel = 'timetravel'
 }
 
 const PanelPaths = {
   [Panel.output]: '/databox.html',
   [Panel.domstate]: '/domstate-panel.html',
+  [Panel.timetravel]: '/hero-script.html',
 };
 
 export default Vue.defineComponent({
@@ -130,6 +132,13 @@ export default Vue.defineComponent({
         this.openPanel(Panel.output, { width: 300, height: 400 });
       }
     },
+    toggleTimetravel(): void {
+      if (this.isPanelOpen(Panel.timetravel)) {
+        this.panelWindow.close();
+      } else {
+        this.openPanel(Panel.timetravel, { width: 1040, height: 500, left: 0, top: 600 });
+      }
+    },
     closeDomState() {
       if (this.isPanelOpen(Panel.domstate)) {
         this.panelWindow.close();
@@ -199,7 +208,7 @@ li {
   @apply flex flex-row border-t py-3 pl-3 pr-2 text-sm cursor-pointer;
   text-shadow: 1px 1px 0 white;
   &.focused {
-    @apply bg-purple-200
+    @apply bg-purple-200;
   }
   &:hover {
     @apply bg-purple-100;

--- a/apps/chromealive-ui/vue.config.js
+++ b/apps/chromealive-ui/vue.config.js
@@ -6,6 +6,7 @@ module.exports = {
     databox: './src/pages/databox/index.ts',
     'domstate-panel': './src/pages/domstate-panel/index.ts',
     'domstate-popup': './src/pages/domstate-popup/index.ts',
+    'hero-script': './src/pages/hero-script/index.ts',
     about: './src/pages/about/index.ts',
   },
 };

--- a/commons/lib/SourceLoader.ts
+++ b/commons/lib/SourceLoader.ts
@@ -1,22 +1,29 @@
 import ISourceCodeLocation from '../interfaces/ISourceCodeLocation';
 import { SourceMapSupport } from './SourceMapSupport';
+import { URL } from 'url';
+import * as fs from 'fs';
 
 export default class SourceLoader {
   private static sourceLines: { [source: string]: string[] } = {};
+  private static fileContentsCache: { [filepath: string]: string } = {};
+
+  static resetCache(): void {
+    this.sourceLines = {};
+    this.fileContentsCache = {};
+  }
+
+  static clearFileCache(filepath: string): void {
+    delete this.fileContentsCache[filepath];
+  }
 
   static getSource(codeLocation: ISourceCodeLocation): ISourceCodeLocation & { code: string } {
     if (!codeLocation) return null;
 
-    const originalSourcePosition = SourceMapSupport.getOriginalSourcePosition(codeLocation);
-    if (originalSourcePosition.source !== codeLocation.filename) {
-      codeLocation = {
-        line: originalSourcePosition.line,
-        filename: originalSourcePosition.source,
-        column: originalSourcePosition.column,
-      };
-    }
+    codeLocation = SourceMapSupport.getOriginalSourcePosition(codeLocation);
+
     if (!this.sourceLines[codeLocation.filename]) {
-      const file = SourceMapSupport.getFileContents(codeLocation.filename);
+      const file = this.getFileContents(codeLocation.filename);
+      if (!file) return null;
       this.sourceLines[codeLocation.filename] = file.split(/\r?\n/);
     }
 
@@ -25,5 +32,28 @@ export default class SourceLoader {
       code,
       ...codeLocation,
     };
+  }
+
+  static getFileContents(filepath: string, cache = true): string {
+    if (cache && this.fileContentsCache[filepath]) return this.fileContentsCache[filepath];
+
+    const originalFilepath = filepath;
+    // Trim the path to make sure there is no extra whitespace.
+    let lookupFilepath: string | URL = filepath.trim();
+    if (filepath.startsWith('file://')) {
+      lookupFilepath = new URL(filepath);
+    }
+
+    let data: string = null;
+    try {
+      data = fs.readFileSync(lookupFilepath, 'utf8');
+    } catch (err) {
+      // couldn't read
+    }
+    if (cache) {
+      this.fileContentsCache[filepath] = data;
+      this.fileContentsCache[originalFilepath] = data;
+    }
+    return data;
   }
 }

--- a/commons/package.json
+++ b/commons/package.json
@@ -5,7 +5,8 @@
   "scripts": {},
   "dependencies": {
     "https-proxy-agent": "^5.0.0",
-    "source-map-js": "^1.0.1"
+    "source-map-js": "^1.0.1",
+    "devtools-protocol": "^0.0.799653"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^5.4.1"

--- a/commons/test/SourceMapSupport.test.ts
+++ b/commons/test/SourceMapSupport.test.ts
@@ -2,12 +2,14 @@ import { SourceMapSupport } from '../lib/SourceMapSupport';
 import { SourceMapGenerator } from 'source-map-js';
 import * as fs from 'fs';
 import * as path from 'path';
+import SourceLoader from '../lib/SourceLoader';
 
 let counter = 0;
 
 beforeEach(() => {
   jest.resetModules();
   SourceMapSupport.resetCache();
+  SourceLoader.resetCache();
   counter += 1;
 });
 

--- a/databox/client/lib/ResourceExtender.ts
+++ b/databox/client/lib/ResourceExtender.ts
@@ -1,5 +1,5 @@
 import { Resource, WebsocketResource } from '@ulixee/hero';
-import { InternalPropertiesSymbol } from '@ulixee/hero/lib/InternalProperties';
+import { InternalPropertiesSymbol } from '@ulixee/hero/lib/internal';
 import type {} from '@ulixee/hero/lib/extendables';
 
 interface IExtendResource {


### PR DESCRIPTION
This PR adds a code viewer that tracks along live with a script, and also during time travel. You can access via the toolbar until we integrate into the extension

This PR merges several hero bugs:
- Timetravel was not working when iframes never get a dom id (it would try to apply them to main frame)
- Boss hanging on close
- Uses EventSubscriber on SessionObserver in ChromeAlive!
