### PR TITLE
Support Range Selection for selector generator

### DIFF
--- a/apps/chromealive-core/apis/AppApi.ts
+++ b/apps/chromealive-core/apis/AppApi.ts
@@ -1,5 +1,4 @@
-import { IBounds } from '@ulixee/apps-chromealive-interfaces/IBounds';
-import { IAppApiStatics } from '@ulixee/apps-chromealive-interfaces/apis/IAppApi';
+import IAppApi, { IAppApiStatics } from '@ulixee/apps-chromealive-interfaces/apis/IAppApi';
 import AliveBarPositioner from '../lib/AliveBarPositioner';
 import ChromeAliveCore from '../index';
 
@@ -9,7 +8,7 @@ export default class AppApi {
     return {};
   }
 
-  static ready(args: { workarea: IBounds; vueServer: string }): void {
+  static ready(args: Parameters<IAppApi['ready']>[0]): void {
     ChromeAliveCore.vueServer = args.vueServer;
     AliveBarPositioner.onAppReady(args.workarea);
   }

--- a/apps/chromealive-core/index.ts
+++ b/apps/chromealive-core/index.ts
@@ -157,6 +157,7 @@ export default class ChromeAliveCore {
       on(sourceCode, 'source', this.sendAppEvent.bind(this, 'SourceCode.updated')),
       on(timetravel, 'new-tick-command', this.sendCommandFocusedEvent.bind(this, sessionId)),
       on(timetravel, 'new-paint-index', this.sendPaintIndexEvent.bind(this, sessionId)),
+      on(timetravel, 'new-offset', this.sendTimetravelOffset.bind(this, sessionId)),
     ];
     this.events.group('session', ...sessionEvents);
 
@@ -195,13 +196,19 @@ export default class ChromeAliveCore {
     this.sendAppEvent('Command.focused', event);
   }
 
+  private static sendTimetravelOffset(
+    sessionId: string,
+    event: TimetravelPlayer['EventTypes']['new-offset'],
+  ): void {
+    this.sendAppEvent('Session.timetravel', event);
+  }
+
   private static sendPaintIndexEvent(
     sessionId: string,
     event: TimetravelPlayer['EventTypes']['new-paint-index'],
   ): void {
     this.sendAppEvent('Dom.focus', {
-      paintIndex: event.paintIndex,
-      highlightPaintIndexRange: [event.paintIndex, event.paintIndex],
+      highlightPaintIndexRange: event.paintIndexRange,
       documentLoadPaintIndex: event.documentLoadPaintIndex,
     });
   }

--- a/apps/chromealive-core/lib/AliveBarPositioner.ts
+++ b/apps/chromealive-core/lib/AliveBarPositioner.ts
@@ -5,8 +5,12 @@ import ChromeAliveCore from '../index';
 
 const { log } = Log(module);
 
+interface IBoundsAndScale extends IBounds {
+  scale: number;
+}
+
 export default class AliveBarPositioner {
-  public static workarea: IBounds;
+  public static workarea: IBoundsAndScale;
   public static chromeToolsTopPadding = 42;
   public static chromeToolsLeftPadding = 100;
   public static chromeToolsWidth = 140;
@@ -25,7 +29,7 @@ export default class AliveBarPositioner {
     [sessionId: string]: IBounds;
   } = {};
 
-  public static getMaxChromeBounds(): IBounds | null {
+  public static getMaxChromeBounds(): IBoundsAndScale | null {
     if (!this.workarea) return null;
 
     return {
@@ -33,6 +37,7 @@ export default class AliveBarPositioner {
       left: this.workarea.left,
       width: this.workarea.width,
       height: this.workarea.height,
+      scale: this.workarea.scale,
     };
   }
 
@@ -119,12 +124,13 @@ export default class AliveBarPositioner {
     }
   }
 
-  public static onAppReady(workarea: IBounds): void {
-    log.info('App workarea setup', { workarea, sessionId: null });
+  public static onAppReady(workarea: IBoundsAndScale): void {
     this.workarea = workarea;
     const maxbounds = this.getMaxChromeBounds();
+
     defaultScreen.width = maxbounds.width;
     defaultScreen.height = maxbounds.height;
+    defaultScreen.scale = maxbounds.scale;
   }
 
   public static restartingSession(sessionId: string): void {

--- a/apps/chromealive-core/lib/HeroCorePlugin.ts
+++ b/apps/chromealive-core/lib/HeroCorePlugin.ts
@@ -97,7 +97,7 @@ export default class HeroCorePlugin extends CorePlugin {
         });
       }
     }
-    await context.newPage();
+    await context.newPage({ runPageScripts: false });
   }
 
   public onBrowserLaunchConfiguration(launchArguments: string[]): void {

--- a/apps/chromealive-extension/package.json
+++ b/apps/chromealive-extension/package.json
@@ -11,7 +11,7 @@
     "build:webpack": "webpack --config webpack.config.js",
     "build:vue": "vue-cli-service build",
     "build": "yarn build:vue && yarn build:webpack",
-    "watch": "vue-cli-service build --watch & webpack --watch --config webpack.config.js"
+    "watch": "concurrently -n vue,webpack \"vue-cli-service build --watch --mode=production\" \"webpack --watch --config webpack.config.js\""
   },
   "dependencies": {
     "@babel/core": "^7.0.0",
@@ -39,6 +39,7 @@
     "autoprefixer": "^9",
     "babel-loader": "^8.2.2",
     "chrome-api-mock": "^0.0.2",
+    "concurrently": "^6.2.1",
     "copy-webpack-plugin": "^9.0.1",
     "glob": "^7.1.6",
     "jest-chrome": "^0.7.2",
@@ -48,7 +49,7 @@
     "tailwindcss": "npm:@tailwindcss/postcss7-compat",
     "ts-loader": "^9.2.6",
     "typescript": "^4.5.5",
-    "webpack": "^5.58.1",
+    "webpack": "^5.70.0",
     "webpack-cli": "^4.9.0"
   },
   "nohoist": [

--- a/apps/chromealive-extension/src/pages/hero-script/index.vue
+++ b/apps/chromealive-extension/src/pages/hero-script/index.vue
@@ -238,6 +238,9 @@ h5 {
       &:hover .call-marker {
         display: block;
       }
+      &.active .call-marker {
+        display: block;
+      }
     }
     &:hover {
       background: aliceblue;

--- a/apps/chromealive-interfaces/apis/IAppApi.ts
+++ b/apps/chromealive-interfaces/apis/IAppApi.ts
@@ -5,7 +5,7 @@ export default interface IAppApi {
     error?: Error;
   };
 
-  ready(args: { workarea: IBounds; vueServer: string }): void;
+  ready(args: { workarea: IBounds & { scale: number }; vueServer: string }): void;
   focus(): void;
 }
 

--- a/apps/chromealive-interfaces/apis/ISessionApi.ts
+++ b/apps/chromealive-interfaces/apis/ISessionApi.ts
@@ -41,6 +41,7 @@ export default interface ISessionApi {
     args: IHeroSessionArgs & {
       commandId?: number;
       percentOffset?: number;
+      timelinePercentRange?: [start: number, end: number];
       step?: 'forward' | 'back';
     },
   ): Promise<{

--- a/apps/chromealive-interfaces/events/IDomFocusEvent.ts
+++ b/apps/chromealive-interfaces/events/IDomFocusEvent.ts
@@ -1,5 +1,4 @@
 export default interface IDomFocusEvent {
-  paintIndex: number;
   highlightPaintIndexRange: [start: number, end: number];
   documentLoadPaintIndex: number;
 }

--- a/apps/chromealive-interfaces/events/ISessionTimetravelEvent.ts
+++ b/apps/chromealive-interfaces/events/ISessionTimetravelEvent.ts
@@ -1,0 +1,5 @@
+export default interface ISessionTimetravelEvent {
+  percentOffset: number;
+  focusedRange: [number, number];
+  tabId: number;
+}

--- a/apps/chromealive-interfaces/events/index.ts
+++ b/apps/chromealive-interfaces/events/index.ts
@@ -8,6 +8,7 @@ import ISourceCodeUpdatedEvent from './ISourceCodeUpdatedEvent';
 import ICommandFocusedEvent from './ICommandFocusedEvent';
 import IDomFocusEvent from './IDomFocusEvent';
 import IDomUpdatedEvent from './IDomUpdatedEvent';
+import ISessionTimetravelEvent from './ISessionTimetravelEvent';
 
 export default interface IChromeAliveEvents {
   'App.show': { onTop: boolean };
@@ -20,6 +21,7 @@ export default interface IChromeAliveEvents {
   'Session.loading': void;
   'Session.loaded': void;
   'Session.active': IHeroSessionActiveEvent;
+  'Session.timetravel': ISessionTimetravelEvent;
   'Databox.updated': IDataboxUpdatedEvent;
   'Dom.updated': IDomUpdatedEvent;
   'Dom.focus': IDomFocusEvent;

--- a/apps/chromealive-ui/src/pages/toolbar/components/OutputButton.vue
+++ b/apps/chromealive-ui/src/pages/toolbar/components/OutputButton.vue
@@ -11,7 +11,7 @@
     <Borders :isSelected="isSelected" :isFocused="isFocused" />
 
     <img src="@/assets/icons/database.svg" class="icon" />
-    <span v-if="!isMinimal" class="label">{{outputSize || 0}}KB Output</span>
+    <span v-if="!isMinimal" class="label">{{outputSize || 0}} Output</span>
   </div>
 </template>
 
@@ -84,7 +84,7 @@
           border-left-color: $bgColorHover;
         }
       }
-    
+
       .icon {
         opacity: $iconOpacityHover;
       }

--- a/apps/chromealive-ui/src/pages/toolbar/components/PlayerBar.vue
+++ b/apps/chromealive-ui/src/pages/toolbar/components/PlayerBar.vue
@@ -1,8 +1,8 @@
 <template>
-  <div 
-    class="PlayerBar relative" 
-    @mousedown="handleMouseDown($event)" 
-    :style="formattedCssVars()" 
+  <div
+    class="PlayerBar relative"
+    @mousedown="handleMouseDown($event)"
+    :style="formattedCssVars()"
     :class="{ isSelected: isSelected, notSelected: !isSelected }"
   >
     <div class="ticks">
@@ -19,7 +19,13 @@
     </div>
 
     <div class="ghost" v-if="isSelected" :class="ghostClass"></div>
-    <div class="marker" v-if="isSelected" ref="markerElem" @mousedown="handleMouseDown($event, 'marker')" :class="{ active: activeItem === 'marker', ...markerClass }">
+    <div
+      class="marker"
+      v-if="isSelected"
+      ref="markerElem"
+      @mousedown="handleMouseDown($event, 'marker')"
+      :class="{ active: activeItem === 'marker', ...markerClass }"
+    >
       <div class="marker-wrapper">
         <div class="dragger left" @mousedown="handleMouseDown($event, 'draggerLeft')"></div>
         <div class="dragger right" @mousedown="handleMouseDown($event, 'draggerRight')"></div>
@@ -28,10 +34,18 @@
       <div class="play-icon"></div>
       <div class="pause-icon"></div>
 
-      <div class="nib left" @mousedown="handleMouseDown($event, 'nibLeft')" :class="{ active: activeItem === 'nibLeft' }">
+      <div
+        class="nib left"
+        @mousedown="handleMouseDown($event, 'nibLeft')"
+        :class="{ active: activeItem === 'nibLeft' }"
+      >
         <div class="arrow-up"></div>
       </div>
-      <div class="nib right" @mousedown="handleMouseDown($event, 'nibRight')" :class="{ active: activeItem === 'nibRight' }">
+      <div
+        class="nib right"
+        @mousedown="handleMouseDown($event, 'nibRight')"
+        :class="{ active: activeItem === 'nibRight' }"
+      >
         <div class="arrow-up"></div>
       </div>
     </div>
@@ -39,629 +53,666 @@
 </template>
 
 <script lang="ts">
-  import * as Vue from 'vue';
-  import Client from '@/api/Client';
-  import ArrowRight from './ArrowRight.vue';
+import * as Vue from 'vue';
+import Client from '@/api/Client';
+import ArrowRight from './ArrowRight.vue';
+import ISessionTimetravelEvent from '@ulixee/apps-chromealive-interfaces/events/ISessionTimetravelEvent';
 
-  const startMarkerPosition = 0;
-  const liveMarkerPosition = 100;
-  const maxMarkerPosition = 103;
+const startMarkerPosition = 0;
+const liveMarkerPosition = 100;
+const maxMarkerPosition = 103;
 
-  const defaultMarkerWidth = 4;
-  const minPixelForMultiple = 4;
+const defaultMarkerWidth = 4;
+const minPixelForMultiple = 4;
 
-  enum MouseDownItem {
-    draggerLeft = 'draggerLeft',
-    draggerRight = 'draggerRight',
-    nibLeft = 'nibLeft',
-    nibRight = 'nibRight',
-    marker = 'marker',
-  }
+enum MouseDownItem {
+  draggerLeft = 'draggerLeft',
+  draggerRight = 'draggerRight',
+  nibLeft = 'nibLeft',
+  nibRight = 'nibRight',
+  marker = 'marker',
+}
 
-  enum ActiveItem {
-    nibLeft = 'nibLeft',
-    nibRight = 'nibRight',
-    marker = 'marker',
-  }
+enum ActiveItem {
+  nibLeft = 'nibLeft',
+  nibRight = 'nibRight',
+  marker = 'marker',
+}
 
-  export default Vue.defineComponent({
-    name: 'PlayerBar',
-    components: {
-      ArrowRight,
-    },
-    props: ['isSelected', 'mouseIsWithinPlayer', 'isRunning', 'ticks', 'session'],
-    emits: ['toggleTimetravel'],
-    setup(props) {
-      const markerElem = Vue.ref<HTMLElement>();
-      const trackRect = Vue.ref<DOMRect>();
-      let markerRect: DOMRect;
+export default Vue.defineComponent({
+  name: 'PlayerBar',
+  components: {
+    ArrowRight,
+  },
+  props: ['isSelected', 'mouseIsWithinPlayer', 'isRunning', 'ticks', 'session'],
+  emits: ['toggleTimetravel'],
+  setup(props) {
+    const markerElem = Vue.ref<HTMLElement>();
+    const trackRect = Vue.ref<DOMRect>();
+    let markerRect: DOMRect;
 
-      const ghostClass = Vue.reactive({
-        show: false,
-        isAtLive: false,
-      });
+    const ghostClass = Vue.reactive({
+      show: false,
+      isAtLive: false,
+    });
 
-      Vue.watch(() => props.mouseIsWithinPlayer, (mouseIsWithinPlayer) => {
+    Vue.watch(
+      () => props.mouseIsWithinPlayer,
+      mouseIsWithinPlayer => {
         if (mouseIsWithinPlayer) {
           trackRect.value = null;
         } else {
           ghostClass.show = false;
         }
-      });
+      },
+    );
 
-      return {
-        trackRect,
-        markerRect,
-        markerElem,
-        activeItem: Vue.ref<ActiveItem | undefined>(),
-        mouseDownItem: Vue.ref<MouseDownItem | undefined>(undefined),
-        markerClass: Vue.reactive<any>({
-          isLive: true,
-          hasMultiple: false,
-        }),
-        ghostClass,
-        cssVars: Vue.ref({
-          markerLeft: liveMarkerPosition,
-          markerRight: null,
-          ghostLeft: 0,
-        }),
-        mousedownX: 0,
-        isMouseDown: Vue.ref(false),
-        isMouseDownDragging: Vue.ref(false),
-        isMaybeClickingPlay: Vue.ref(false),
+    return {
+      trackRect,
+      markerRect,
+      markerElem,
+      activeItem: Vue.ref<ActiveItem | undefined>(),
+      mouseDownItem: Vue.ref<MouseDownItem | undefined>(undefined),
+      markerClass: Vue.reactive({
+        isLive: true,
+        hasMultiple: false,
+        isPlaying: false,
+      }),
+      ghostClass,
+      cssVars: Vue.ref({
+        markerLeft: liveMarkerPosition,
+        markerRight: null,
+        ghostLeft: 0,
+      }),
+      mousedownX: 0,
+      isMouseDown: Vue.ref(false),
+      isMouseDownDragging: Vue.ref(false),
+      isMaybeClickingPlay: Vue.ref(false),
 
-        pendingTimetravelOffset: null as number,
-        timetravelTimeout: -1,
-        lastTimetravelTimestamp: -1,
-      }
+      pendingTimetravelOffset: null as number,
+      timetravelTimeout: -1,
+      lastTimetravelTimestamp: -1,
+    };
+  },
+  methods: {
+    formattedCssVars() {
+      return Object.entries(this.cssVars).reduce((byKey, [key, value]) => {
+        byKey[`--${key}`] = value;
+        return byKey;
+      }, {});
     },
-    methods: {
-      formattedCssVars() {
-        return Object.entries(this.cssVars).reduce((byKey, [key, value]) => {
-          byKey[`--${key}`] = value;
-          return byKey;
-        }, {});
-      },
 
-      nextTickWidth(urlIndex: number) {
-        if (urlIndex === this.ticks.length - 1) return '2px';
-        const diff = this.ticks[urlIndex + 1].offsetPercent - this.ticks[urlIndex].offsetPercent;
-        return `${diff}%`;
-      },
+    async doTimetravel() {
+      if (this.pendingTimetravelOffset === null) return;
+      if (Date.now() - this.lastTimetravelTimestamp < 250) {
+        if (this.timetravelTimeout) return;
+        this.timetravelTimeout = setTimeout(this.doTimetravel, 100) as any;
+        return;
+      }
 
-      async doTimetravel() {
-        if (this.pendingTimetravelOffset === null) return;
-        if (Date.now() - this.lastTimetravelTimestamp < 250) {
-          if (this.timetravelTimeout) return;
-          this.timetravelTimeout = setTimeout(this.doTimetravel, 100) as any;
-          return;
-        }
+      this.lastTimetravelTimestamp = Date.now();
+      const percentOffset = this.pendingTimetravelOffset;
+      const isLiveMode = percentOffset === 100;
+      this.$emit('toggleTimetravel', isLiveMode);
+      this.clearPendingTimetravel();
+      const isMultiple = this.markerClass.hasMultiple;
 
-        const percentOffset = this.pendingTimetravelOffset;
-        const isLiveMode = percentOffset === 100;
-        this.$emit('toggleTimetravel', isLiveMode);
-        this.clearPendingTimetravel();
-        
-        await Client.send('Session.timetravel', {
-          heroSessionId: this.session?.heroSessionId,
-          percentOffset,
-        });
-      },
+      await Client.send('Session.timetravel', {
+        heroSessionId: this.session?.heroSessionId,
+        timelinePercentRange: isMultiple
+          ? [this.cssVars.markerLeft, 100 - this.cssVars.markerRight]
+          : [percentOffset, percentOffset],
+        percentOffset,
+      });
+    },
 
-      clearPendingTimetravel() {
-        clearTimeout(this.timetravelTimeout);
-        this.timetravelTimeout = null;
-        this.pendingTimetravelOffset = null;
-      },
+    clearPendingTimetravel() {
+      clearTimeout(this.timetravelTimeout);
+      this.timetravelTimeout = null;
+      this.pendingTimetravelOffset = null;
+    },
 
-      convertLeftMousePctToPixels(pctPos): number {
-        const trackRect = this.getTrackBoundingRect();
-        return trackRect.width * (pctPos / 100);
-      },
+    convertLeftMousePctToPixels(pctPos): number {
+      const trackRect = this.getTrackBoundingRect();
+      return trackRect.width * (pctPos / 100);
+    },
 
-      convertGlobalMouseLeftToPct(mousePosX: number): number {
-        const trackRect = this.getTrackBoundingRect();
-        return ((mousePosX - trackRect.x) / trackRect.width) * 100;
-      },
+    convertGlobalMouseLeftToPct(mousePosX: number): number {
+      const trackRect = this.getTrackBoundingRect();
+      return ((mousePosX - trackRect.x) / trackRect.width) * 100;
+    },
 
-      getTrackBoundingRect(): DOMRect {
-        this.trackRect ??= this.$el.getBoundingClientRect();
-        return this.trackRect;
-      },
+    getTrackBoundingRect(): DOMRect {
+      this.trackRect ??= this.$el.getBoundingClientRect();
+      return this.trackRect;
+    },
 
-      getMarkerBoundingRect(): DOMRect {
-        this.markerRect ??= this.markerElem.getBoundingClientRect();
-        return this.markerRect;
-      },
+    getMarkerBoundingRect(): DOMRect {
+      this.markerRect ??= this.markerElem.getBoundingClientRect();
+      return this.markerRect;
+    },
 
-      handleMouseDown(event: MouseEvent, item?: MouseDownItem) {
-        if (event.button !== 0) return;
-        if (!this.isSelected) return;
-        event.preventDefault();
+    handleMouseDown(event: MouseEvent, item?: MouseDownItem) {
+      if (event.button !== 0) return;
+      if (!this.isSelected) return;
+      event.preventDefault();
 
-        if (item === MouseDownItem.marker) {
-          if (!this.markerClass.isLive) {
-            event.stopPropagation();
-            return;
-          } else {
-            this.isMaybeClickingPlay = true;
-            item = MouseDownItem.nibLeft;
-          }
-        }
-        this.mouseDownItem = item;
-        this.trackRect = null;
-        this.ghostClass.show = false;
-        this.mousedownX = event.pageX;
-        this.isMouseDown = true;
-
-        if (!item) {
-          this.showMarker(event);
-        } else if (ActiveItem[item]) {
-          this.activeItem = item as unknown as ActiveItem;
-        }
-
-        event.stopPropagation();
-      },
-
-      handleMouseup(event: MouseEvent) {
-        if (!this.isSelected) return;
-        if (event.button !== 0) return;
-        event.preventDefault();
-
-        if (this.isMaybeClickingPlay && !this.isMouseDownDragging) {
-          this.togglePlay();
-        }
-
-        const leftAsRight = 100 - this.cssVars.markerLeft;
-        const markerPos1 = this.convertLeftMousePctToPixels(leftAsRight);
-        const markerPos2 = this.convertLeftMousePctToPixels(this.cssVars.markerRight);
-        if (Math.abs(markerPos1 - markerPos2) < minPixelForMultiple) {
-          this.cssVars.markerRight = '';
-          this.markerClass.hasMultiple = false;
-          this.activeItem = this.activeItem === ActiveItem.nibRight ? ActiveItem.nibLeft : this.activeItem;
-          if (this.activeItem === ActiveItem.nibLeft) {
-            this.pendingTimetravelOffset = this.cssVars.markerLeft;
-            this.doTimetravel();
-          }
-        }
-
-        this.isMouseDown = false;
-        this.isMouseDownDragging = false;
-        this.isMaybeClickingPlay = false;
-        this.mouseDownItem = undefined;
-        this.$el.style.cursor = '';
-        this.markerRect = null;
-      },
-
-      togglePlay() {
-        if (this.markerClass.isPlaying) {
-          this.pauseScript();
-        } else {
-          this.resumeScript();
-        }
-      },
-
-      resumeScript() {
-        this.markerClass.isPlaying = true;
-
-      },
-
-      pauseScript() {
-        this.markerClass.isPlaying = false;
-      },
-
-      showMarker(event: MouseEvent) {
-        this.activeItem = ActiveItem.nibLeft;
-        this.markerClass.isLive = false;
-        this.markerClass.hasMultiple = false;
-        this.cssVars.markerRight = '';
-        let markerLeftPct = this.convertGlobalMouseLeftToPct(event.pageX - 3);
-        if (markerLeftPct >= 100) {
-          markerLeftPct = 100;
-          this.markerClass.isLive = true;
-        } else if (markerLeftPct < 0) {
-          markerLeftPct = 0;
-        }
-        this.cssVars.markerLeft = markerLeftPct;
+      if (item === MouseDownItem.marker) {
         if (!this.markerClass.isLive) {
+          event.stopPropagation();
+          return;
+        } else {
+          this.isMaybeClickingPlay = true;
+          item = MouseDownItem.nibLeft;
+        }
+      }
+      this.mouseDownItem = item;
+      this.trackRect = null;
+      this.ghostClass.show = false;
+      this.mousedownX = event.pageX;
+      this.isMouseDown = true;
+
+      if (!item) {
+        this.showMarker(event);
+      } else if (ActiveItem[item]) {
+        this.activeItem = item as unknown as ActiveItem;
+      }
+
+      event.stopPropagation();
+    },
+
+    handleMouseup(event: MouseEvent) {
+      if (!this.isSelected) return;
+      if (event.button !== 0) return;
+      event.preventDefault();
+
+      if (this.isMaybeClickingPlay && !this.isMouseDownDragging) {
+        this.togglePlay();
+      }
+
+      const leftAsRight = 100 - this.cssVars.markerLeft;
+      const markerPos1 = this.convertLeftMousePctToPixels(leftAsRight);
+      const markerPos2 = this.convertLeftMousePctToPixels(this.cssVars.markerRight);
+      if (Math.abs(markerPos1 - markerPos2) < minPixelForMultiple) {
+        this.cssVars.markerRight = '';
+        this.markerClass.hasMultiple = false;
+        this.activeItem =
+          this.activeItem === ActiveItem.nibRight ? ActiveItem.nibLeft : this.activeItem;
+        if (this.activeItem === ActiveItem.nibLeft) {
           this.pendingTimetravelOffset = this.cssVars.markerLeft;
           this.doTimetravel();
         }
-      },
+      }
 
-      handleMousemove(event: MouseEvent) {
-        if (!this.isSelected) return;
-
-        if (!this.isMouseDown) {
-          this.tryToShowGhost(event);
-          return;
+      if (this.activeItem === ActiveItem.nibLeft || this.activeItem === ActiveItem.nibRight) {
+        this.lastTimetravelTimestamp = -1;
+        if (!this.pendingTimetravelOffset) {
+          const isRightNib = this.activeItem === ActiveItem.nibRight;
+          this.pendingTimetravelOffset = isRightNib
+            ? 100 - this.cssVars.markerRight
+            : this.cssVars.markerLeft;
         }
+        this.doTimetravel();
+      }
 
-        if (Math.abs(event.pageX - this.mousedownX) >= minPixelForMultiple) {
-          this.isMouseDownDragging = true;
-        }
-        if ([MouseDownItem.nibLeft, MouseDownItem.nibRight].includes(this.mouseDownItem)) {
-          this.handleDraggingNib(event);
-        } else if ([MouseDownItem.draggerLeft, MouseDownItem.draggerRight].includes(this.mouseDownItem)) {
-          this.handleDraggingNib(event);
-        } else if (!this.mouseDownItem) {
-          this.handleDraggingNew(event);
-        }
-      },
+      this.isMouseDown = false;
+      this.isMouseDownDragging = false;
+      this.isMaybeClickingPlay = false;
+      this.mouseDownItem = undefined;
+      this.$el.style.cursor = '';
+      this.markerRect = null;
+    },
 
-      tryToShowGhost(event: MouseEvent) {
-        if (!this.mouseIsWithinPlayer) {
-          this.ghostClass.show = false;
-          return;
-        }
-        const trackRect = this.getTrackBoundingRect();
-        if (event.pageX < trackRect.x) {
-          this.ghostClass.show = false;
-          return;
-        }
+    togglePlay() {
+      if (this.markerClass.isPlaying) {
+        this.pauseScript();
+      } else {
+        this.resumeScript();
+      }
+    },
 
-        const spaceBefore = this.markerClass.isLive ? 1 : 3;
-        const spaceAfter = this.markerClass.isLive ? 5 : 3;
-        const markerRect = this.getMarkerBoundingRect();
-        const markerLeft = markerRect.x;
-        const markerRight = markerLeft + markerRect.width;
-        if (event.pageX > (markerLeft - spaceBefore) && event.pageX < (markerRight + spaceAfter)) {
-          this.ghostClass.show = false;
-          return;
-        }
+    resumeScript() {
+      this.markerClass.isPlaying = true;
+    },
 
-        this.ghostClass.isAtLive = false;
-        this.ghostClass.show = true;
-        let ghostLeftPct = this.convertGlobalMouseLeftToPct(event.pageX - 3);
-        if (ghostLeftPct >= liveMarkerPosition) {
-          ghostLeftPct = liveMarkerPosition;
-          this.ghostClass.isAtLive = true;
-        } else if (ghostLeftPct < 0) {
-          ghostLeftPct = 0;
-        }
-        this.cssVars.ghostLeft = ghostLeftPct;
-      },
+    pauseScript() {
+      this.markerClass.isPlaying = false;
+    },
 
-      handleDraggingNib(event: MouseEvent) {
-        let mousePctLeft = this.convertGlobalMouseLeftToPct(event.pageX - 3);
-
-        this.markerClass.isLive = false;
-        if (!this.markerClass.hasMultiple && mousePctLeft >= liveMarkerPosition) {
-          mousePctLeft = liveMarkerPosition;
-          this.markerClass.isLive = true;
-        } else if (this.markerClass.hasMultiple && mousePctLeft >= maxMarkerPosition) {
-          mousePctLeft = maxMarkerPosition;
-        } else if (mousePctLeft < startMarkerPosition) {
-          mousePctLeft = startMarkerPosition;
-        }
-        if ([MouseDownItem.nibLeft, MouseDownItem.draggerLeft].includes(this.mouseDownItem)) {
-          this.cssVars.markerLeft = mousePctLeft;
-        } else {
-          this.cssVars.markerRight = 100 - mousePctLeft;
-        }
-
-        if (!this.markerClass.isLive) {
-          this.pendingTimetravelOffset = this.activeItem === ActiveItem.nibRight ? this.cssVars.markerRight : this.cssVars.markerLeft;
-          this.doTimetravel();
-        }
-      },
-
-      handleDraggingNew(event: MouseEvent) {
-        if (this.markerClass.isLive) return;
-        const dragLength = event.pageX - this.mousedownX;
-        if (Math.abs(dragLength) < minPixelForMultiple) return;
-
-        this.$el.style.cursor = 'col-resize';
-        this.markerClass.hasMultiple = true;
-
-        if (dragLength < 0) {
-          const mousePctRight = 100 - this.convertGlobalMouseLeftToPct(this.mousedownX + 3)
-          let mousePctLeft = this.convertGlobalMouseLeftToPct(this.mousedownX + dragLength - 3);
-          if (mousePctLeft >= maxMarkerPosition) {
-            mousePctLeft = maxMarkerPosition;
-          } else if (mousePctLeft < startMarkerPosition) {
-            mousePctLeft = 0;
-          }
-
-          this.cssVars.markerRight = mousePctRight;
-          this.cssVars.markerLeft = mousePctLeft;
-          this.activeItem = ActiveItem.nibLeft;
-        } else {
-          let mousePctLeft = this.convertGlobalMouseLeftToPct(event.pageX);
-          this.markerClass.isLive = false;
-          if (mousePctLeft >= maxMarkerPosition) {
-            mousePctLeft = maxMarkerPosition;
-          } else if (mousePctLeft < startMarkerPosition) {
-            mousePctLeft = 0;
-          }
-
-          const mousePctRight = 100 - mousePctLeft;
-          this.cssVars.markerRight = mousePctRight;
-          this.activeItem = ActiveItem.nibRight;
-        }
-
-        this.pendingTimetravelOffset = this.activeItem === ActiveItem.nibRight ? this.cssVars.markerRight : this.cssVars.markerLeft;
+    showMarker(event: MouseEvent) {
+      this.activeItem = ActiveItem.nibLeft;
+      this.markerClass.isLive = false;
+      this.markerClass.hasMultiple = false;
+      this.cssVars.markerRight = '';
+      let markerLeftPct = this.convertGlobalMouseLeftToPct(event.pageX - 3);
+      if (markerLeftPct >= 100) {
+        markerLeftPct = 100;
+        this.markerClass.isLive = true;
+      } else if (markerLeftPct < 0) {
+        markerLeftPct = 0;
+      }
+      this.cssVars.markerLeft = markerLeftPct;
+      if (!this.markerClass.isLive) {
+        this.pendingTimetravelOffset = this.cssVars.markerLeft;
         this.doTimetravel();
       }
     },
-    mounted() {
-      window.addEventListener('mouseup', this.handleMouseup);
-      window.addEventListener('mousemove', this.handleMousemove.bind(this));
+
+    handleMousemove(event: MouseEvent) {
+      if (!this.isSelected) return;
+
+      if (!this.isMouseDown) {
+        this.tryToShowGhost(event);
+        return;
+      }
+
+      if (Math.abs(event.pageX - this.mousedownX) >= minPixelForMultiple) {
+        this.isMouseDownDragging = true;
+      }
+      if ([MouseDownItem.nibLeft, MouseDownItem.nibRight].includes(this.mouseDownItem)) {
+        this.handleDraggingNib(event);
+      } else if (
+        [MouseDownItem.draggerLeft, MouseDownItem.draggerRight].includes(this.mouseDownItem)
+      ) {
+        this.handleDraggingNib(event);
+      } else if (!this.mouseDownItem) {
+        this.handleDraggingNew(event);
+      }
     },
-    beforeUnmount() {
-      window.removeEventListener('mousemove', this.handleMousemove.bind(this));
+
+    tryToShowGhost(event: MouseEvent) {
+      if (!this.mouseIsWithinPlayer) {
+        this.ghostClass.show = false;
+        return;
+      }
+      const trackRect = this.getTrackBoundingRect();
+      if (event.pageX < trackRect.x) {
+        this.ghostClass.show = false;
+        return;
+      }
+
+      const spaceBefore = this.markerClass.isLive ? 1 : 3;
+      const spaceAfter = this.markerClass.isLive ? 5 : 3;
+      const markerRect = this.getMarkerBoundingRect();
+      const markerLeft = markerRect.x;
+      const markerRight = markerLeft + markerRect.width;
+      if (event.pageX > markerLeft - spaceBefore && event.pageX < markerRight + spaceAfter) {
+        this.ghostClass.show = false;
+        return;
+      }
+
+      this.ghostClass.isAtLive = false;
+      this.ghostClass.show = true;
+      let ghostLeftPct = this.convertGlobalMouseLeftToPct(event.pageX - 3);
+      if (ghostLeftPct >= liveMarkerPosition) {
+        ghostLeftPct = liveMarkerPosition;
+        this.ghostClass.isAtLive = true;
+      } else if (ghostLeftPct < 0) {
+        ghostLeftPct = 0;
+      }
+      this.cssVars.ghostLeft = ghostLeftPct;
     },
-  });
+
+    handleDraggingNib(event: MouseEvent) {
+      let mousePctLeft = this.convertGlobalMouseLeftToPct(event.pageX - 3);
+
+      this.markerClass.isLive = false;
+      if (!this.markerClass.hasMultiple && mousePctLeft >= liveMarkerPosition) {
+        mousePctLeft = liveMarkerPosition;
+        this.markerClass.isLive = true;
+      } else if (this.markerClass.hasMultiple && mousePctLeft >= maxMarkerPosition) {
+        mousePctLeft = maxMarkerPosition;
+      } else if (mousePctLeft < startMarkerPosition) {
+        mousePctLeft = startMarkerPosition;
+      }
+      if ([MouseDownItem.nibLeft, MouseDownItem.draggerLeft].includes(this.mouseDownItem)) {
+        this.cssVars.markerLeft = mousePctLeft;
+      } else {
+        this.cssVars.markerRight = 100 - mousePctLeft;
+      }
+
+      if (!this.markerClass.isLive) {
+        this.pendingTimetravelOffset =
+          this.activeItem === ActiveItem.nibRight
+            ? 100 - this.cssVars.markerRight
+            : this.cssVars.markerLeft;
+        this.doTimetravel();
+      }
+    },
+
+    handleDraggingNew(event: MouseEvent) {
+      if (this.markerClass.isLive) return;
+      const dragLength = event.pageX - this.mousedownX;
+      if (Math.abs(dragLength) < minPixelForMultiple) return;
+
+      this.$el.style.cursor = 'col-resize';
+      this.markerClass.hasMultiple = true;
+
+      if (dragLength < 0) {
+        const mousePctRight = 100 - this.convertGlobalMouseLeftToPct(this.mousedownX + 3);
+        let mousePctLeft = this.convertGlobalMouseLeftToPct(this.mousedownX + dragLength - 3);
+        if (mousePctLeft >= maxMarkerPosition) {
+          mousePctLeft = maxMarkerPosition;
+        } else if (mousePctLeft < startMarkerPosition) {
+          mousePctLeft = 0;
+        }
+
+        this.cssVars.markerRight = mousePctRight;
+        this.cssVars.markerLeft = mousePctLeft;
+        this.activeItem = ActiveItem.nibLeft;
+      } else {
+        let mousePctLeft = this.convertGlobalMouseLeftToPct(event.pageX);
+        this.markerClass.isLive = false;
+        if (mousePctLeft >= maxMarkerPosition) {
+          mousePctLeft = maxMarkerPosition;
+        } else if (mousePctLeft < startMarkerPosition) {
+          mousePctLeft = 0;
+        }
+
+        const mousePctRight = 100 - mousePctLeft;
+        this.cssVars.markerRight = mousePctRight;
+        this.activeItem = ActiveItem.nibRight;
+      }
+
+      this.pendingTimetravelOffset =
+        this.activeItem === ActiveItem.nibRight
+          ? 100 - this.cssVars.markerRight
+          : this.cssVars.markerLeft;
+      this.doTimetravel();
+    },
+
+    onTimetraveled(event: ISessionTimetravelEvent): void {
+      if (event.focusedRange) {
+        this.markerClass.hasMultiple = true;
+        this.cssVars.markerLeft = event.focusedRange[0];
+        this.cssVars.markerRight = 100 - event.focusedRange[1];
+      } else {
+        this.markerClass.hasMultiple = false;
+        this.cssVars.markerLeft = event.percentOffset;
+        this.cssVars.markerRight = 100 - event.percentOffset;
+      }
+    },
+  },
+  mounted() {
+    Client.on('Session.timetravel', this.onTimetraveled);
+    window.addEventListener('mouseup', this.handleMouseup);
+    window.addEventListener('mousemove', this.handleMousemove.bind(this));
+  },
+  beforeUnmount() {
+    window.removeEventListener('mousemove', this.handleMousemove.bind(this));
+  },
+});
 </script>
 
 <style lang="scss" scoped="scoped">
-  @use "sass:math";
-  @import "../variables";
+@use "sass:math";
+@import '../variables';
 
-  .PlayerBar {
-    height: 100%;
+.PlayerBar {
+  height: 100%;
 
-    &.notSelected {
-      .ticks {
-        display: none;
-      }
+  &.notSelected {
+    .ticks {
+      display: none;
     }
   }
+}
 
-  .ghost {
-    position: absolute;
-    top: -4px;
-    left: calc(100% * var(--ghostLeft) / 100);
-    height: calc(100% + 8px);
-    border: 1px solid #9B43C0;
-    width: 4px;
-    border-radius: 5px;
-    background: rgba(255,255,255,0.7);
-    z-index: 11;
-    display: none;
-    opacity: 0.5;
-    &.show {
+.ghost {
+  position: absolute;
+  top: -4px;
+  left: calc(100% * var(--ghostLeft) / 100);
+  height: calc(100% + 8px);
+  border: 1px solid #9b43c0;
+  width: 4px;
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.7);
+  z-index: 11;
+  display: none;
+  opacity: 0.5;
+  &.show {
+    display: block;
+  }
+  &.isAtLive {
+    width: 31px;
+    height: 31px;
+    top: -1.5px;
+    border-radius: 50%;
+    margin-left: -13px;
+  }
+}
+.marker {
+  position: absolute;
+  top: -4px;
+  height: calc(100% + 8px);
+  min-width: 4px;
+  z-index: 12;
+  left: calc(100% * var(--markerLeft) / 100);
+
+  &.isLive.isPlaying {
+    animation: pulse-animation 1s infinite;
+    .pause-icon {
       display: block;
     }
-    &.isAtLive {
-      width: 31px;
-      height: 31px;
-      top: -1.5px;
-      border-radius: 50%;
-      margin-left: -13px;
+    .play-icon {
+      display: none;
     }
   }
-  .marker {
-    position: absolute;
-    top: -4px;
-    height: calc(100% + 8px);
-    min-width: 4px;
-    z-index: 12;
-    left: calc(100% * var(--markerLeft) / 100);
 
-    &.isLive.isPlaying {
-      animation: pulse-animation 1s infinite;
-      .pause-icon {
-        display: block;
-      }
-      .play-icon {
-        display: none;
-      }
+  @keyframes pulse-animation {
+    0% {
+      box-shadow: 0 0 0 0px rgba(169, 36, 223, 0.5);
     }
-
-    @keyframes pulse-animation {
-      0% {
-        box-shadow: 0 0 0 0px rgba(169, 36, 223, 0.5);
-      }
-      100% {
-        box-shadow: 0 0 0 10px rgba(169, 36, 223, 0);
-      }
+    100% {
+      box-shadow: 0 0 0 10px rgba(169, 36, 223, 0);
     }
+  }
 
-    &.isLive {
-      width: 32px;
-      height: 32px;
-      top: -2.5px;
-      border-radius: 50%;
-      margin-left: -13px;
-      &:hover {
-        box-shadow: 1px 1px 3px 2px rgba(95, 0, 134, 0.3);
-      }
-      .play-icon {
-        display: block;
-      }
-      .dragger {
-        display: none !important;
-      }
-      .marker-wrapper {
-        border-radius: 50%;
-        &:before, &:after {
-          border-radius: 50%;
-        }
-        &:after {
-          background: white;
-        }
-      }
-      .nib {
-        display: none !important;
-      }
+  &.isLive {
+    width: 32px;
+    height: 32px;
+    top: -2.5px;
+    border-radius: 50%;
+    margin-left: -13px;
+    &:hover {
+      box-shadow: 1px 1px 3px 2px rgba(95, 0, 134, 0.3);
     }
-
-    &.hasMultiple {
-      right: calc(100% * var(--markerRight) / 100);
-      .dragger {
-        display: block;
-      }
+    .play-icon {
+      display: block;
     }
-
-    &.hasMultiple {
-      .nib {
-        display: block;
-      }
-    }
-
-    .nib {
-      position: absolute;
-      display: none;
-      z-index: 5;
-      top: calc(100% + 2px);
-      width: 14px;
-      height: 6px;
-      background: #AB87BB;
-      border: 1px solid #8B5E97;
-      border-top: none;
-      box-shadow: 1px 1px 4px rgba(0,0,0,0.3);
-
-      &.left {
-        left: -5px;
-        display: block;
-      }
-      &.right {
-        right: -5px;
-      }
-      &.active {
-        background: white;
-        .arrow-up:before {
-          background: white;
-        }
-      }
-
-      $arrowUpSize: 14.6;
-      .arrow-up {
-        width: #{$arrowUpSize}px;
-        height: #{$arrowUpSize}px;
-        overflow: hidden;
-        position: absolute;
-        bottom: 100%;
-        left: -1px;
-
-        &::before {
-          content: '';
-          display: block;
-          width:  math.div($arrowUpSize, 1.41) * 1px;
-          height: math.div($arrowUpSize, 1.41) * 1px;
-          position: absolute;
-          bottom: 0;
-          left: -0.5px;
-          background: #AB87BB;
-          border: 1px solid #8B5E97;
-          transform: rotate(45deg);
-          transform-origin: 0 100%;
-        }
-      }
-    }
-
-    .marker-wrapper {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      overflow: hidden;
-      border-radius: 5px;
-      box-shadow: 1px 1px 3px rgba(0,0,0,0.1);
-      background: rgba(255,255,255,0.2);
-      &:before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        border: 3px solid white;
-        border-radius: 5px;
-      }
-
-      &:after {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        border: 1.5px solid #9B43C0;
-        border-radius: 5px;
-      }
-    }
-
     .dragger {
-      position: absolute;
-      display: none;
-      top: 0;
-      height: 100%;
-      width: 2px;
-      cursor: col-resize;
-      z-index: 1;
-      &.left {
-        left: 0;
+      display: none !important;
+    }
+    .marker-wrapper {
+      border-radius: 50%;
+      &:before,
+      &:after {
+        border-radius: 50%;
       }
-      &.right {
-        right: 0;
+      &:after {
+        background: white;
+      }
+    }
+    .nib {
+      display: none !important;
+    }
+  }
+
+  &.hasMultiple {
+    right: calc(100% * var(--markerRight) / 100);
+    .dragger {
+      display: block;
+    }
+  }
+
+  &.hasMultiple {
+    .nib {
+      display: block;
+    }
+  }
+
+  .nib {
+    position: absolute;
+    display: none;
+    z-index: 5;
+    top: calc(100% + 2px);
+    width: 14px;
+    height: 6px;
+    background: #ab87bb;
+    border: 1px solid #8b5e97;
+    border-top: none;
+    box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.3);
+
+    &.left {
+      left: -5px;
+      display: block;
+    }
+    &.right {
+      right: -5px;
+    }
+    &.active {
+      background: white;
+      .arrow-up:before {
+        background: white;
+      }
+    }
+
+    $arrowUpSize: 14.6;
+    .arrow-up {
+      width: #{$arrowUpSize}px;
+      height: #{$arrowUpSize}px;
+      overflow: hidden;
+      position: absolute;
+      bottom: 100%;
+      left: -1px;
+
+      &::before {
+        content: '';
+        display: block;
+        width: math.div($arrowUpSize, 1.41) * 1px;
+        height: math.div($arrowUpSize, 1.41) * 1px;
+        position: absolute;
+        bottom: 0;
+        left: -0.5px;
+        background: #ab87bb;
+        border: 1px solid #8b5e97;
+        transform: rotate(45deg);
+        transform-origin: 0 100%;
       }
     }
   }
 
-  .play-icon {
+  .marker-wrapper {
     position: absolute;
-    display: none;
-    top: calc(50% - 8px);
-    left: calc(50% - 3px);
-    width: 0;
-    height: 0;
-    border-top: 8px solid transparent;
-    border-bottom: 8px solid transparent;
-    border-left: 9px solid #9A78A8;
-  }
-
-  .pause-icon {
-    position: absolute;
-    display: none;
-    top: calc(50% - 8px);
-    left: calc(50% - 5px);
-    width: 10px;
-    height: 16px;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    border-radius: 5px;
+    box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.1);
+    background: rgba(255, 255, 255, 0.2);
     &:before {
       content: '';
       position: absolute;
       top: 0;
       left: 0;
-      width: 3px;
+      width: 100%;
       height: 100%;
-      background: #9A78A8;
+      border: 3px solid white;
+      border-radius: 5px;
     }
+
     &:after {
       content: '';
       position: absolute;
       top: 0;
-      right: 0;
-      width: 3px;
+      left: 0;
+      width: 100%;
       height: 100%;
-      background: #9A78A8;
+      border: 1.5px solid #9b43c0;
+      border-radius: 5px;
     }
   }
 
-  .ticks {
+  .dragger {
     position: absolute;
-    width: 100%;
-    left: 0;
-    height: 24px;
-    top: calc(50% - 12px);
-    z-index: 5;
-    .tick {
-      position: absolute;
-      width: 2px;
-      background: rgba(0,0,0,0.3);
-      border-right: 1px solid rgba(255,255,255,0.9);
-      top: 0;
-      height: 100%;
+    display: none;
+    top: 0;
+    height: 100%;
+    width: 2px;
+    cursor: col-resize;
+    z-index: 1;
+    &.left {
+      left: 0;
+    }
+    &.right {
+      right: 0;
     }
   }
+}
 
-  .ArrowRight {
-    right: -27px;
+.play-icon {
+  position: absolute;
+  display: none;
+  top: calc(50% - 8px);
+  left: calc(50% - 3px);
+  width: 0;
+  height: 0;
+  border-top: 8px solid transparent;
+  border-bottom: 8px solid transparent;
+  border-left: 9px solid #9a78a8;
+}
+
+.pause-icon {
+  position: absolute;
+  display: none;
+  top: calc(50% - 8px);
+  left: calc(50% - 5px);
+  width: 10px;
+  height: 16px;
+  &:before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 3px;
+    height: 100%;
+    background: #9a78a8;
   }
-  
-  button {
-    cursor: default;
+  &:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 3px;
+    height: 100%;
+    background: #9a78a8;
   }
+}
+
+.ticks {
+  position: absolute;
+  width: 100%;
+  left: 0;
+  height: 24px;
+  top: calc(50% - 12px);
+  z-index: 5;
+  .tick {
+    position: absolute;
+    width: 2px;
+    background: rgba(0, 0, 0, 0.3);
+    border-right: 1px solid rgba(255, 255, 255, 0.9);
+    top: 0;
+    height: 100%;
+  }
+}
+
+.ArrowRight {
+  right: -27px;
+}
+
+button {
+  cursor: default;
+}
 </style>

--- a/apps/chromealive/lib/ChromeAlive.ts
+++ b/apps/chromealive/lib/ChromeAlive.ts
@@ -240,7 +240,12 @@ export class ChromeAlive extends EventEmitter {
 
     await this.injectCoreServer(this.#toolbarWindow);
 
-    const workareaBounds = { left: workarea.x, top: workarea.y, ...workarea };
+    const workareaBounds = {
+      left: workarea.x,
+      top: workarea.y,
+      ...workarea,
+      scale: mainScreen.scaleFactor,
+    };
     await this.#api.send('App.ready', {
       workarea: workareaBounds,
       vueServer: `http://localhost:${vueServerAddress.port}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -19433,7 +19433,7 @@ webpack@^4.0.0:
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
 
-webpack@^5.54.0:
+webpack@^5.54.0, webpack@^5.70.0:
   version "5.70.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.70.0.tgz#3461e6287a72b5e6e2f4872700bc8de0d7500e6d"
   integrity sha512-ZMWWy8CeuTTjCxbeaQI21xSswseF2oNOwc70QSKNePvmxE7XW36i7vpBMYZFAUHPwQiEbNGCEYIOOlyRbdGmxw==


### PR DESCRIPTION
This PR does the following:
1. Select a range of ticks in Selector Generator when dragging the playbar
2. Correctly toggle between ticks in playbar when clicking one or the other
3. Send the correct offset for the right tick in the playbar (was sending % offset right)
4. Correctly debounce sending timetravel api requests
5. Broadcast all playbar percent changes so that navigating HeroScript moves the playbar