### PR TITLE
Various ChromeAlive + Databox fixes

### DIFF
--- a/apps/chromealive-core/index.ts
+++ b/apps/chromealive-core/index.ts
@@ -120,10 +120,9 @@ export default class ChromeAliveCore {
       pageId,
     });
 
-    if (this.activeHeroSessionId) {
-      if (status.focused) AliveBarPositioner.focusedPageId(pageId);
-      else AliveBarPositioner.blurredPageId(pageId);
-    } else {
+    if (this.activeHeroSessionId === heroSessionId && status.focused) {
+      AliveBarPositioner.focusedPageId(pageId);
+    } else if (!this.restartingHeroSessionId) {
       AliveBarPositioner.blurredPageId(pageId);
     }
   }
@@ -206,7 +205,9 @@ export default class ChromeAliveCore {
 
     if (!this.activeHeroSessionId || isRestartedSessionId) {
       this.restartingHeroSessionId = null;
-      this.sendAppEvent('Session.loading');
+      if (!isRestartedSessionId) {
+        this.sendAppEvent('Session.loading');
+      }
       AliveBarPositioner.showHeroSessionOnBounds(sessionId);
       this.events.once(sessionObserver, 'hero:updated', () => {
         this.sendAppEvent('Session.loaded');
@@ -266,7 +267,7 @@ export default class ChromeAliveCore {
         this.sendAppEvent('Session.active', {
           heroSessionId: null,
           timeline: { urls: [], screenshots: [], paintEvents: [], storageEvents: [] },
-          playbackState: 'finished',
+          playbackState: 'restarting',
           startTime: Date.now(),
           inputBytes: 0,
           runtimeMs: 0,

--- a/apps/chromealive-extension/.prettierrc
+++ b/apps/chromealive-extension/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "printWidth": 100,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "arrowParens": "avoid"
+}

--- a/apps/chromealive-interfaces/events/IHeroSessionActiveEvent.ts
+++ b/apps/chromealive-interfaces/events/IHeroSessionActiveEvent.ts
@@ -8,7 +8,7 @@ export default interface IHeroSessionActiveEvent {
   scriptLastModifiedTime: number;
   heroSessionId: string;
   inputBytes: number;
-  playbackState: 'running' | 'paused' | 'finished';
+  playbackState: 'running' | 'paused' | 'finished' | 'restarting';
   runtimeMs: number;
   timeline: ITimelineMetadata;
 }

--- a/apps/chromealive-ui/.eslintrc.js
+++ b/apps/chromealive-ui/.eslintrc.js
@@ -1,7 +1,11 @@
 const Path = require('path');
 
 module.exports = {
-  extends: ['../../.eslintrc.js', 'plugin:vue/vue3-recommended', '@vue/typescript/recommended'],
+  extends: [
+    '../../.eslintrc.js',
+    'plugin:vue/vue3-recommended',
+    '@vue/typescript/recommended'
+  ],
   plugins: ['monorepo-cop'],
   parser: 'vue-eslint-parser',
   parserOptions: {
@@ -16,14 +20,17 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
     'vue/multi-word-component-names': 'off',
-    "vue/max-attributes-per-line": ["error", {
-      "singleline": {
-        "max": 2
+    'vue/max-attributes-per-line': [
+      'error',
+      {
+        singleline: {
+          max: 2,
+        },
+        multiline: {
+          max: 1,
+        },
       },
-      "multiline": {
-        "max": 1
-      }
-    }]
+    ],
   },
   overrides: [
     {

--- a/apps/chromealive-ui/.prettierrc
+++ b/apps/chromealive-ui/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "printWidth": 100,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "arrowParens": "avoid"
+}

--- a/apps/chromealive-ui/src/pages/toolbar/index.vue
+++ b/apps/chromealive-ui/src/pages/toolbar/index.vue
@@ -1,6 +1,6 @@
 <template>
-  <div id="ChromeAliveToolbar" :class="{ loading: isLoading }">
-    <SessionController></SessionController>
+  <div id="ChromeAliveToolbar" :class="{ loading: isLoading, restarting: isRestarting }">
+    <SessionController />
   </div>
 </template>
 
@@ -18,6 +18,7 @@ export default Vue.defineComponent({
 
     return {
       isLoading: Vue.ref(false),
+      isRestarting: Vue.ref(false),
     };
   },
 
@@ -28,6 +29,9 @@ export default Vue.defineComponent({
   mounted() {
     Client.on('Session.loading', () => {
       this.isLoading = true;
+    });
+    Client.on('Session.active', (session) => {
+      this.isRestarting = session?.playbackState === 'restarting';
     });
     Client.on('Session.loaded', () => {
       this.isLoading = false
@@ -69,9 +73,10 @@ body {
   height: 36px;
   background: white;
 
-  &.loading > * {
-    opacity: 0.5;
-    border: 1px solid #3c3c3c;
+  &.restarting {
+    background: transparent;
+    opacity: 1;
+    border: none;
   }
 }
 

--- a/apps/chromealive-ui/src/pages/toolbar/views/SessionController.vue
+++ b/apps/chromealive-ui/src/pages/toolbar/views/SessionController.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="bar-wrapper flex flex-row items-stretch">
+  <div class="bar-wrapper flex flex-row items-stretch" :class="{ isRestarting }">
     <MenuButton class="z-20" />
     <InputButton
       :is-selected="mode === 'Input'"
@@ -17,7 +17,7 @@
       :is-minimal="isMinimal"
       :session="session"
       :timetravel="timetravel"
-      class="flex-1 z-10"
+      class="z-10 flex-1"
       @select="selectPlayerMode"
       @toggleFinder="onFinderModeToggled"
     />
@@ -47,12 +47,12 @@ import IAppModeEvent from '@ulixee/apps-chromealive-interfaces/events/IAppModeEv
 import IDataboxOutputEvent from '@ulixee/apps-chromealive-interfaces/events/IDataboxOutputEvent';
 import { ChevronDownIcon } from '@heroicons/vue/outline';
 import humanizeBytes from '@/utils/humanizeBytes';
+import ISessionTimetravelEvent from '@ulixee/apps-chromealive-interfaces/events/ISessionTimetravelEvent';
 import MenuButton from '../components/MenuButton.vue';
 import InputButton from '../components/InputButton.vue';
 import Player from '../components/Player.vue';
 import OutputButton from '../components/OutputButton.vue';
 import ReliabilityButton from '../components/ReliabilityButton.vue';
-import ISessionTimetravelEvent from '@ulixee/apps-chromealive-interfaces/events/ISessionTimetravelEvent';
 
 type IStartLocation = 'currentLocation' | 'sessionStart';
 
@@ -79,10 +79,12 @@ export default Vue.defineComponent({
       const value = mode.value;
       return value === 'Live' || value === 'Timetravel' || value === 'Finder';
     });
+    const isRestarting = Vue.computed(() => session?.playbackState === 'restarting');
 
     return {
       session,
       isPlayerSelected,
+      isRestarting,
       mode,
       previousPlayerMode: Vue.ref<IAppModeEvent['mode']>(mode.value),
       isMinimal: Vue.ref(false),
@@ -90,7 +92,7 @@ export default Vue.defineComponent({
       timelineTicks: Vue.ref<any[]>([]),
       outputSize: Vue.ref<string>(humanizeBytes(0)),
       inputSize: Vue.ref<string>(humanizeBytes(0)),
-      timetravel: Vue.ref<{ url: string, percentOffset: number }>(null),
+      timetravel: Vue.ref<{ url: string; percentOffset: number }>(null),
     };
   },
   async created() {
@@ -211,7 +213,7 @@ function createDefaultSession(): IHeroSessionActiveEvent {
 </script>
 
 <style lang="scss" scoped>
-@use "sass:math";
+@use 'sass:math';
 @import '../variables.scss';
 
 :root {
@@ -222,5 +224,14 @@ function createDefaultSession(): IHeroSessionActiveEvent {
   background-color: var(--toolbarBackgroundColor);
   height: 36px;
   cursor: default;
+  &.isRestarting {
+    background-color: transparent;
+    .MenuButton,
+    .InputButton,
+    .OutputButton,
+    .ReliabilityButton {
+      visibility: hidden;
+    }
+  }
 }
 </style>

--- a/databox/ROADMAP-Databox.md
+++ b/databox/ROADMAP-Databox.md
@@ -1,6 +1,5 @@
 ## 2.1
 We want to be able to “build” a databox into a package that can be deployed onto a server where it can be run efficiently to output only data.
-- Optimization
 - Localization Configuration 
 
 ## 2.6 - Virtual Machines

--- a/databox/client/lib/DataboxInternal.ts
+++ b/databox/client/lib/DataboxInternal.ts
@@ -51,7 +51,14 @@ export default class DataboxInternal<TInput, TOutput> extends TypedEventEmitter<
 
   public async execRunner(runFn: IRunFn<TInput, TOutput>): Promise<void> {
     const runner = new Runner<TInput, TOutput>(this);
-    await runFn(runner);
+    try {
+      await runFn(runner);
+    } catch (error) {
+      if (error.stack.includes('at async DataboxInternal.execRunner')) {
+        error.stack = error.stack.split('at async DataboxInternal.execRunner').shift().trim();
+      }
+      throw error;
+    }
   }
 
   public close(): Promise<void> {
@@ -60,7 +67,7 @@ export default class DataboxInternal<TInput, TOutput> extends TypedEventEmitter<
     this.#isClosing = new Promise(async (resolve, reject) => {
       try {
         await Promise.all(this.#extractorPromises).catch(err => err);
-        
+
         resolve();
       } catch (error) {
         reject(error);

--- a/databox/client/lib/DataboxWrapper.ts
+++ b/databox/client/lib/DataboxWrapper.ts
@@ -6,7 +6,9 @@ import IComponents, { IRunFn } from '../interfaces/IComponents';
 import DataboxInternal from './DataboxInternal';
 import { setupAutorunBeforeExitHook, attemptAutorun } from './utils/Autorun';
 
-export default class DataboxWrapper<TInput = IBasicInput, TOutput = any> implements IDataboxWrapper {
+export default class DataboxWrapper<TInput = IBasicInput, TOutput = any>
+  implements IDataboxWrapper
+{
   public static defaultExport: DataboxWrapper;
 
   public disableAutorun: boolean;
@@ -22,28 +24,26 @@ export default class DataboxWrapper<TInput = IBasicInput, TOutput = any> impleme
             run: components,
           }
         : { ...components };
-    
+
     this.disableAutorun = !!process.env.ULX_DATABOX_DISABLE_AUTORUN;
   }
 
   public async run(options: IDataboxRunOptions = {}): Promise<TOutput> {
-    const databoxInternal = new DataboxInternal<TInput, TOutput>(
-      options,
-      this.#components.defaults,
-    );
+    let databoxInternal: DataboxInternal<TInput, TOutput>;
+
     try {
+      databoxInternal = new DataboxInternal(options, this.#components.defaults);
       await databoxInternal.execRunner(this.#components.run);
 
+      this.successCount++;
+      return databoxInternal.output;
     } catch (error) {
       console.error(`ERROR running databox: `, error);
       this.errorCount++;
       throw error;
     } finally {
-      await databoxInternal.close();
+      await databoxInternal?.close();
     }
-    
-    this.successCount++;
-    return databoxInternal.output;
   }
 
   public static run<T>(databoxWrapper: DataboxWrapper): Promise<T | Error> {

--- a/databox/for-hero/core/index.ts
+++ b/databox/for-hero/core/index.ts
@@ -31,7 +31,7 @@ export default class DataboxForHeroCore implements IDataboxModuleRunner {
   });
 
   public async start(): Promise<void> {
-    process.env.ULX_DATABOX_DISABLE_AUTORUN = 'Y';
+    process.env.ULX_DATABOX_DISABLE_AUTORUN = 'true';
     await HeroCore.start();
     const bridge = new TransportBridge();
     HeroCore.addConnection(bridge.transportToClient);

--- a/databox/for-puppeteer/client/lib/DataboxInternal.ts
+++ b/databox/for-puppeteer/client/lib/DataboxInternal.ts
@@ -56,7 +56,14 @@ export default class DataboxInternal<TInput, TOutput> extends TypedEventEmitter<
   public async execRunner(runFn: IRunFn<TInput, TOutput>): Promise<void> {
     const runner = new Runner<TInput, TOutput>(this);
     this.puppeteerBrowser = await this.puppeteerBrowserPromise;
-    await runFn(runner);
+    try {
+      await runFn(runner);
+    } catch (error) {
+      if (error.stack.includes('at async DataboxInternal.execRunner')) {
+        error.stack = error.stack.split('at async DataboxInternal.execRunner').shift().trim();
+      }
+      throw error;
+    }
   }
 
   public close(): Promise<void> {

--- a/databox/for-puppeteer/client/lib/DataboxWrapper.ts
+++ b/databox/for-puppeteer/client/lib/DataboxWrapper.ts
@@ -29,19 +29,21 @@ export default class DataboxWrapper<TInput = IBasicInput, TOutput = any>
   }
 
   public async run(options: IDataboxForPuppeteerRunOptions = {}): Promise<TOutput> {
-    const databoxInternal = new DataboxInternal(options, this.#components.defaults);
+    let databoxInternal: DataboxInternal<TInput, TOutput>;
+
     try {
+      databoxInternal = new DataboxInternal(options, this.#components.defaults);
       await databoxInternal.execRunner(this.#components.run);
+
+      this.successCount++;
+      return databoxInternal.output;
     } catch (error) {
       console.error(`ERROR running databox: `, error);
       this.errorCount++;
       throw error;
     } finally {
-      await databoxInternal.close();
+      await databoxInternal?.close();
     }
-
-    this.successCount++;
-    return databoxInternal.output;
   }
 
   public static run<T>(databoxWrapper: DataboxWrapper): Promise<T | Error> {

--- a/playgrounds/databox-for-hero/index.ts
+++ b/playgrounds/databox-for-hero/index.ts
@@ -28,6 +28,7 @@ export default class DataboxPlayground extends DataboxWrapper {
       const server = new UlixeeServer();
       await server.listen();
       serverHost = await server.address;
+      HeroCore.onShutdown = () => server.close();
       console.log('Started Ulixee server at %s', serverHost);
       ShutdownHandler.register(() => server.close());
     }

--- a/playgrounds/hero/index.ts
+++ b/playgrounds/hero/index.ts
@@ -24,6 +24,7 @@ async function getCoreServerHost(): Promise<string> {
     await server.listen();
     serverHost = await server.address;
     console.log('Started Ulixee server at %s', serverHost);
+    Core.onShutdown = () => server.close();
     ShutdownHandler.register(() => server.close());
   } else {
     console.log('Connecting to Ulixee server at %s', serverHost);


### PR DESCRIPTION
- Properly log errors that occur in constructor of Databoxes (ie, no server host found errors)
- Restart Databox sessions properly
- Show ChromeAlive restarting state
- Fix repo-tools/prettier for the vue apps
- Split Databox error stacks so they don't include internals of Databoxes