### PR TITLE
fix: autorun was not setup correctly after previous databox changes

### DIFF
--- a/databox/client/index.mjs
+++ b/databox/client/index.mjs
@@ -1,22 +1,11 @@
+import { setupAutorunMjsHack } from './lib/utils/Autorun.mjs';
 import cjsImport from './index.js';
 
-const { Runner } = cjsImport;
+const { RunnerObject } = cjsImport;
 
-export { Runner };
+export { RunnerObject };
 
 export default cjsImport.default;
 
-//////////////////////////////////////////////////////////////////////////////////////////
-// this hack allows DataboxWrapper's beforeExit to know if the mjs script has a default export
-
-export function setupAutorunMjsHack() {
-  const module = import(process.argv[1]);
-  module.then(x => {
-    if (x.default instanceof cjsImport.default) {
-      cjsImport.default.defaultExport = x.default;
-    }
-  });
-}
-
-setupAutorunMjsHack();
+setupAutorunMjsHack(cjsImport.default);
 

--- a/databox/client/lib/utils/Autorun.mjs
+++ b/databox/client/lib/utils/Autorun.mjs
@@ -1,0 +1,10 @@
+// this hack allows DataboxWrapper's beforeExit to know if the mjs script has a default export
+
+export function setupAutorunMjsHack(DataboxWrapper) {
+  const module = import(process.argv[1]);
+  module.then(x => {
+    if (x.default instanceof DataboxWrapper) {
+      DataboxWrapper.defaultExport = x.default;
+    }
+  });
+}

--- a/databox/for-hero/client/index.mjs
+++ b/databox/for-hero/client/index.mjs
@@ -1,10 +1,10 @@
-import { setupAutorunMjsHack } from '@ulixee/databox/index.mjs';
+import { setupAutorunMjsHack } from '@ulixee/databox/lib/utils/Autorun.mjs';
 import cjsImport from './index.js';
 
-const { Observable, Runner, Extractor } = cjsImport;
+const { Observable, RunnerObject, ExtractorObject } = cjsImport;
 
-export { Observable, Runner, Extractor };
+export { Observable, RunnerObject, ExtractorObject };
 
 export default cjsImport.default;
 
-setupAutorunMjsHack();
+setupAutorunMjsHack(cjsImport.default);

--- a/databox/for-hero/client/lib/DataboxWrapper.ts
+++ b/databox/for-hero/client/lib/DataboxWrapper.ts
@@ -1,3 +1,4 @@
+import { setupAutorunBeforeExitHook } from '@ulixee/databox/lib/utils/Autorun';
 import IBasicInput from '@ulixee/databox-interfaces/IBasicInput';
 import IDataboxWrapper from '@ulixee/databox-interfaces/IDataboxWrapper';
 import DataboxWrapperAbstract from '@ulixee/databox/lib/abstracts/DataboxWrapperAbstract';
@@ -48,3 +49,5 @@ extends DataboxWrapperAbstract<
     return new DataboxInternal(options, this.components.defaults);
   }
 }
+
+setupAutorunBeforeExitHook(DataboxWrapper);

--- a/databox/for-puppeteer/client/index.mjs
+++ b/databox/for-puppeteer/client/index.mjs
@@ -1,10 +1,10 @@
-import { setupAutorunMjsHack } from '@ulixee/databox/index.mjs';
+import { setupAutorunMjsHack } from '@ulixee/databox/lib/utils/Autorun.mjs';
 import cjsImport from './index.js';
 
-const { Runner } = cjsImport;
+const { RunnerObject } = cjsImport;
 
-export { Runner };
+export { RunnerObject };
 
 export default cjsImport.default;
 
-setupAutorunMjsHack();
+setupAutorunMjsHack(cjsImport.default);

--- a/databox/for-puppeteer/client/lib/DataboxWrapper.ts
+++ b/databox/for-puppeteer/client/lib/DataboxWrapper.ts
@@ -1,7 +1,6 @@
-import readCommandLineArgs from '@ulixee/databox/lib/utils/readCommandLineArgs';
 import IBasicInput from '@ulixee/databox-interfaces/IBasicInput';
 import IDataboxWrapper from '@ulixee/databox-interfaces/IDataboxWrapper';
-import { setupAutorunBeforeExitHook, attemptAutorun } from '@ulixee/databox/lib/utils/Autorun';
+import { setupAutorunBeforeExitHook } from '@ulixee/databox/lib/utils/Autorun';
 import DataboxWrapperAbstract from '@ulixee/databox/lib/abstracts/DataboxWrapperAbstract';
 import IDataboxForPuppeteerRunOptions from '../interfaces/IDataboxForPuppeteerRunOptions';
 import IComponents from '../interfaces/IComponents';


### PR DESCRIPTION
The previous databox refactoring introduced two bugs which are fixed in this PR:

- setupAutorunBeforeExitHook wasn't being called on for-hero and for-puppeteer

- The setupAutorunMjsHack in index.mjs wasn't working in at least for-hero and for-puppeteer.