### PR TITLE
Schema Interfaces

### DIFF
--- a/apps/chromealive-core/lib/SessionObserver.ts
+++ b/apps/chromealive-core/lib/SessionObserver.ts
@@ -467,7 +467,7 @@ export default class SessionObserver extends TypedEventEmitter<{
       }
     }
     for (const name of assetNames.snippets) {
-      const snippets = await this.heroSession.getDataSnippets(sessionId, name);
+      const snippets = await this.heroSession.getSnippets(sessionId, name);
       for (const snippet of snippets as IDataboxCollectedAssets['dataSnippets']) {
         this.addSourceCodeLocation(snippet);
         result.dataSnippets.push(snippet);

--- a/databox/client/cli.ts
+++ b/databox/client/cli.ts
@@ -1,5 +1,8 @@
 import { Command } from 'commander';
 import type * as CliCommands from '@ulixee/databox-packager/lib/cliCommands';
+import UlixeeServerConfig from '@ulixee/commons/config/servers';
+import UlixeeConfig from '@ulixee/commons/config';
+import DataboxApiClient from './lib/DataboxApiClient';
 
 const { version } = require('./package.json');
 
@@ -77,10 +80,7 @@ export default function databoxCommands(): Command {
       '<path>',
       'The path of the entrypoint to the Databox. Must have a default export that is a Databox.',
     )
-    .option(
-      '-o, --out-dir <path>',
-      'A directory path where you want packaged .dbx files to be saved',
-    )
+    .option('-o, --out-dir <path>', 'A directory path where you want .dbx packages to be saved')
     .option('-u, --upload', 'Upload this package to a Ulixee Server after packaging.', false)
     .addOption(uploadHostOption)
     .addOption(clearVersionHistoryOption)
@@ -118,7 +118,7 @@ export default function databoxCommands(): Command {
   databoxCommand
     .command('open')
     .description('Open a Databox package in the local working directory.')
-    .argument('<dbxPath>', 'The path to the packaged .dbx file.')
+    .argument('<dbxPath>', 'The path to the .dbx package.')
     .action(async dbxPath => {
       await getPackagerCommands().unpack(dbxPath);
     });
@@ -126,16 +126,36 @@ export default function databoxCommands(): Command {
   databoxCommand
     .command('close')
     .description('Close the Databox package and save or discard the local changes.')
-    .argument('<dbxPath>', 'The path to the packaged .dbx file.')
+    .argument('<dbxPath>', 'The path to the .dbx package.')
     .option('-x, --discard-changes', 'Remove the working directory without saving any changes')
     .action(async (dbxPath, { discardChanges }) => {
       await getPackagerCommands().closeDbx(dbxPath, discardChanges);
     });
 
   databoxCommand
+    .command('install')
+    .description(
+      'Install a Databox and corresponding Schema into your project. Enables type-checking for Databox.exec.',
+    )
+    .argument('<versionHash>', 'The version hash of the Databox.')
+    .option('-a, --alias <name>', 'Add a shortcut name to reference this Databox hash.')
+    .option('-h, --host <host>', 'Connect to the given host server. Will try to automatically connect if omitted.')
+    .action(async (versionHash, { alias, host }) => {
+      host ??=
+        UlixeeConfig.load()?.serverHost ??
+        UlixeeConfig.global.serverHost ??
+        UlixeeServerConfig.global.getVersionHost(version);
+
+      if (!host) throw new Error('Please provide a server host to connect to.');
+
+      const client = new DataboxApiClient(host);
+      await client.install(versionHash, alias);
+    });
+
+  databoxCommand
     .command('upload')
     .description('Upload a Databox package to a server.')
-    .argument('<dbxPath>', 'The path to the packaged .dbx file.')
+    .argument('<dbxPath>', 'The path to the .dbx package.')
     .addOption(uploadHostOption)
     .option(
       '-a, --allow-new-version-history',

--- a/databox/client/index.ts
+++ b/databox/client/index.ts
@@ -3,6 +3,8 @@ import Databox from './lib/DataboxExecutable';
 import DataboxObject from './lib/DataboxObject';
 import { Observable } from './lib/ObjectObserver';
 
+export * as schema from '@ulixee/schema';
+
 export { Databox, Observable, DataboxObject };
 
 export default Databox;

--- a/databox/client/lib/DataboxApiClient.ts
+++ b/databox/client/lib/DataboxApiClient.ts
@@ -5,6 +5,11 @@ import { concatAsBuffer } from '@ulixee/commons/lib/bufferUtils';
 import Identity from '@ulixee/crypto/lib/Identity';
 import ValidationError from '@ulixee/specification/utils/ValidationError';
 import { IPayment } from '@ulixee/specification';
+import IDataboxInputOutput from '@ulixee/databox-interfaces/IDataboxInputOutput';
+import ITypes from '../types';
+import installSchemaType, { addSchemaAlias } from '../types/installSchemaType';
+
+type IDataboxExecResult = Omit<IDataboxApiTypes['Databox.exec']['result'], 'output'>;
 
 export default class DataboxApiClient {
   public connectionToCore: ConnectionToCore<IDataboxApis, {}>;
@@ -23,11 +28,30 @@ export default class DataboxApiClient {
     return await this.runRemote('Databox.meta', { versionHash });
   }
 
-  public async run(
+  public async install(
     versionHash: string,
-    input: any,
+    alias?: string,
+  ): Promise<IDataboxApiTypes['Databox.meta']['result']> {
+    const meta = await this.getMeta(versionHash);
+    if (meta.schemaInterface) {
+      installSchemaType(meta.schemaInterface, versionHash);
+    }
+    if (alias) {
+      addSchemaAlias(versionHash, alias);
+    }
+
+    return meta;
+  }
+
+  public async exec<
+    IO extends IDataboxInputOutput,
+    IVersionHash extends keyof ITypes & string = any,
+    ISchemaDbx extends ITypes[IVersionHash] = IO,
+  >(
+    versionHash: IVersionHash,
+    input: ISchemaDbx['input'],
     payment?: IPayment,
-  ): Promise<IDataboxApiTypes['Databox.exec']['result']> {
+  ): Promise<IDataboxExecResult & { output?: ISchemaDbx['output'] }> {
     return await this.runRemote('Databox.exec', { versionHash, payment, input });
   }
 

--- a/databox/client/lib/DataboxExecutable.ts
+++ b/databox/client/lib/DataboxExecutable.ts
@@ -18,6 +18,10 @@ export default class DataboxExecutable<ISchema extends IDataboxSchema = IDatabox
   public readonly corePlugins: { [name: string]: string } = {};
   public readonly plugins: Plugins<ISchema>;
 
+  public get schema(): ISchema {
+    return this.components.schema;
+  }
+
   public disableAutorun: boolean;
   public successCount = 0;
   public errorCount = 0;

--- a/databox/client/package.json
+++ b/databox/client/package.json
@@ -12,14 +12,15 @@
     },
     "./package.json": "./package.json",
     "./lib/utils/Autorun.mjs": "./lib/utils/Autorun.mjs",
-    "./lib/*": "./lib/*.js"
+    "./lib/*": "./lib/*.js",
+    "./types/*": "./types/*"
   },
   "dependencies": {
     "@ulixee/commons": "2.0.0-alpha.12",
     "@ulixee/crypto": "2.0.0-alpha.12",
     "@ulixee/databox-interfaces": "2.0.0-alpha.12",
-    "@ulixee/schema": "2.0.0-alpha.12",
     "@ulixee/net": "2.0.0-alpha.12",
+    "@ulixee/schema": "2.0.0-alpha.12",
     "@ulixee/specification": "2.0.0-alpha.12",
     "commander": "^9.3.0",
     "yargs-parser": "^20.2.9"

--- a/databox/client/test/types.test.ts
+++ b/databox/client/test/types.test.ts
@@ -1,0 +1,90 @@
+import * as Fs from 'fs';
+import { encodeBuffer } from '@ulixee/commons/lib/bufferUtils';
+import { sha3 } from '@ulixee/commons/lib/hashUtils';
+import installSchemaType, { addSchemaAlias } from '../types/installSchemaType';
+
+beforeEach(() => {
+  Fs.writeFileSync(
+    `${__dirname}/../types/index.d.ts`,
+    `import IDataboxInputOutput from '@ulixee/databox-interfaces/IDataboxInputOutput';
+export default interface ITypes extends Record<string, IDataboxInputOutput> {}`,
+  );
+});
+
+it('can install a schema', async () => {
+  const schema = `{
+    input: {
+      var1: string;
+    };
+    output: {
+      test2?: string;
+    };
+  }`;
+  installSchemaType(schema, 'thisIsATest');
+
+  expect(Fs.existsSync(`${__dirname}/../types/thisIsATest.d.ts`)).toBe(true);
+  expect(Fs.readFileSync(`${__dirname}/../types/index.d.ts`, 'utf8'))
+    .toBe(`import IDataboxInputOutput from '@ulixee/databox-interfaces/IDataboxInputOutput';
+import thisIsATest from './thisIsATest';
+export default interface ITypes extends Record<string, IDataboxInputOutput> {
+  "thisIsATest": thisIsATest;
+}`);
+});
+
+it('can install multiple schemas', async () => {
+  const schema1 = `{
+    input: {
+      var1: string;
+    };
+    output: {
+      test2?: string;
+    };
+  }`;
+  const schema2 = `{
+    input: {
+      vars: string;
+    };
+    output: {
+      nothing: boolean;
+    };
+  }`;
+  const id1 = encodeBuffer(sha3('schema1'), 'dbx');
+  const id2 = encodeBuffer(sha3('schema2'), 'dbx');
+  installSchemaType(schema1, id1);
+  installSchemaType(schema2, id2);
+
+  expect(Fs.existsSync(`${__dirname}/../types/${id1}.d.ts`)).toBe(true);
+  expect(Fs.existsSync(`${__dirname}/../types/${id2}.d.ts`)).toBe(true);
+  expect(Fs.readFileSync(`${__dirname}/../types/index.d.ts`, 'utf8'))
+    .toBe(`import IDataboxInputOutput from '@ulixee/databox-interfaces/IDataboxInputOutput';
+import ${id1} from './${id1}';
+import ${id2} from './${id2}';
+export default interface ITypes extends Record<string, IDataboxInputOutput> {
+  "${id1}": ${id1};
+  "${id2}": ${id2};
+}`);
+
+  // test an alias
+  addSchemaAlias(id2, 'short2');
+  expect(Fs.readFileSync(`${__dirname}/../types/index.d.ts`, 'utf8'))
+    .toBe(`import IDataboxInputOutput from '@ulixee/databox-interfaces/IDataboxInputOutput';
+import ${id1} from './${id1}';
+import ${id2} from './${id2}';
+export default interface ITypes extends Record<string, IDataboxInputOutput> {
+  "${id1}": ${id1};
+  "${id2}": ${id2};
+  "short2": ${id2};
+}`);
+
+  // test overwriting a value
+  addSchemaAlias(id1, 'short2');
+  expect(Fs.readFileSync(`${__dirname}/../types/index.d.ts`, 'utf8'))
+    .toBe(`import IDataboxInputOutput from '@ulixee/databox-interfaces/IDataboxInputOutput';
+import ${id1} from './${id1}';
+import ${id2} from './${id2}';
+export default interface ITypes extends Record<string, IDataboxInputOutput> {
+  "${id1}": ${id1};
+  "${id2}": ${id2};
+  "short2": ${id1};
+}`);
+});

--- a/databox/client/types/index.ts
+++ b/databox/client/types/index.ts
@@ -1,0 +1,3 @@
+import IDataboxInputOutput from '@ulixee/databox-interfaces/IDataboxInputOutput';
+
+export default interface ITypes extends Record<string, IDataboxInputOutput> {}

--- a/databox/client/types/installSchemaType.ts
+++ b/databox/client/types/installSchemaType.ts
@@ -1,0 +1,53 @@
+import * as Fs from 'fs';
+
+const emptyJsFile = `"use strict";\nObject.defineProperty(exports, "__esModule", { value: true });`;
+
+export default function installSchemaType(schemaInterface: string, versionHash: string): void {
+  // don't install a broken schema
+  if (!schemaInterface.startsWith('{') || !schemaInterface.endsWith('}')) {
+    console.warn(
+      'The requested schema interface cannot be installed - it must be a full type.',
+      schemaInterface,
+    );
+    return;
+  }
+  if (!schemaInterface.includes('input: ') && !schemaInterface.includes('output: ')) {
+    console.warn(
+      'The requested schema interface cannot be installed - it must include either an input or an output specification.',
+      schemaInterface,
+    );
+    return;
+  }
+  if (schemaInterface) {
+    Fs.writeFileSync(
+      `${__dirname}/${versionHash}.d.ts`,
+      `export default interface ISchema ${schemaInterface}`,
+    );
+    // add a js file so you can import
+    Fs.writeFileSync(`${__dirname}/${versionHash}.js`, emptyJsFile);
+  }
+  addTypeReference(versionHash, versionHash);
+}
+
+function addTypeReference(name: string, versionHash: string): void {
+  let source = Fs.readFileSync(`${__dirname}/index.d.ts`, 'utf8');
+  if (!source.includes(`import ${versionHash}`)) {
+    source = source.replace(
+      `\nexport default interface`,
+      `\nimport ${versionHash} from './${versionHash}';\nexport default interface`,
+    );
+  }
+
+  if (source.includes(`"${name}":`)) {
+    source = source.replace(new RegExp(`"${name}": [a-zA-Z0-9_]+;`), `"${name}": ${versionHash};`);
+  } else {
+    source = source
+      .replace('{}', '{\n}')
+      .replace(/(}[\n\s]*)$/, `  "${name}": ${versionHash};\n$1`);
+  }
+  Fs.writeFileSync(`${__dirname}/index.d.ts`, source);
+}
+
+export function addSchemaAlias(versionHash: string, aliasName: string): void {
+  addTypeReference(aliasName, versionHash);
+}

--- a/databox/core/bin/databox-process.ts
+++ b/databox/core/bin/databox-process.ts
@@ -24,6 +24,7 @@ process.on('message', async (message: IMessage) => {
       data: {
         coreVersion: databoxExecutable.coreVersion,
         corePlugins: databoxExecutable.corePlugins || {},
+        schema: databoxExecutable.schema,
       },
     });
   }

--- a/databox/core/endpoints/Databox.meta.ts
+++ b/databox/core/endpoints/Databox.meta.ts
@@ -26,7 +26,7 @@ export default new DataboxApiHandler('Databox.meta', {
       maxBytesPerQuery: databox.stats.maxBytes,
       basePricePerQuery: databox.pricePerQuery,
       computePricePerKb: context.configuration.computePricePerKb,
-      schema: null,
+      schemaInterface: databox.schemaInterface,
     };
   },
 });

--- a/databox/core/interfaces/ILocalDataboxProcess.ts
+++ b/databox/core/interfaces/ILocalDataboxProcess.ts
@@ -1,3 +1,6 @@
+import IDataboxSchema from '@ulixee/databox-interfaces/IDataboxSchema';
+import { IAnySchemaJson } from '@ulixee/schema/interfaces/ISchemaJson';
+
 export interface IFetchMetaMessage {
   messageId: string;
   action: 'fetchMeta';
@@ -20,6 +23,10 @@ export interface IExecResponseData {
 export interface IFetchMetaResponseData {
   coreVersion: string;
   corePlugins: { [name: string]: string };
+  schema?: Omit<IDataboxSchema, 'input' | 'output'> & {
+    input?: Record<string, IAnySchemaJson>;
+    output?: Record<string, IAnySchemaJson> | IAnySchemaJson;
+  };
 }
 
 export type IResponseData = IExecResponseData | IFetchMetaResponseData;
@@ -28,4 +35,3 @@ export interface IResponse {
   responseId: string;
   data: IResponseData;
 }
-

--- a/databox/core/lib/DataboxManifest.ts
+++ b/databox/core/lib/DataboxManifest.ts
@@ -26,6 +26,7 @@ export default class DataboxManifest implements IDataboxManifest {
   public scriptEntrypoint: string;
   public coreVersion: string;
   public corePlugins: { [name: string]: string };
+  public schemaInterface: string;
 
   // Payment details
   public pricePerQuery?: number;
@@ -77,6 +78,7 @@ export default class DataboxManifest implements IDataboxManifest {
     versionTimestamp: number,
     coreVersion: string,
     corePlugins: { [name: string]: string },
+    schemaInterface: string | undefined,
     logger?: (message: string, ...args: any[]) => any,
   ): Promise<void> {
     await this.load();
@@ -89,6 +91,7 @@ export default class DataboxManifest implements IDataboxManifest {
     this.linkedVersions ??= [];
     this.coreVersion = coreVersion;
     this.corePlugins = corePlugins;
+    this.schemaInterface = schemaInterface;
     // allow manifest to override above values
     await this.loadExplicitSettings(manifestSources, logger);
 
@@ -182,6 +185,7 @@ export default class DataboxManifest implements IDataboxManifest {
       paymentAddress: this.paymentAddress,
       giftCardAddress: this.giftCardAddress,
       pricePerQuery: this.pricePerQuery,
+      schemaInterface: this.schemaInterface,
     };
   }
 

--- a/databox/core/lib/DataboxesTable.ts
+++ b/databox/core/lib/DataboxesTable.ts
@@ -19,6 +19,7 @@ export default class DataboxesTable extends SqliteTable<IDataboxRecord> {
         ['pricePerQuery', 'INTEGER'],
         ['scriptHash', 'TEXT'],
         ['scriptEntrypoint', 'TEXT'],
+        ['schemaInterface', 'TEXT'],
         ['coreVersion', 'TEXT'],
         ['corePlugins', 'TEXT'],
         ['storedDate', 'DATETIME'],
@@ -39,6 +40,7 @@ export default class DataboxesTable extends SqliteTable<IDataboxRecord> {
       manifest.pricePerQuery,
       manifest.scriptHash,
       manifest.scriptEntrypoint,
+      manifest.schemaInterface,
       manifest.coreVersion,
       JSON.stringify(manifest.corePlugins),
       storedDate,
@@ -52,6 +54,7 @@ export default class DataboxesTable extends SqliteTable<IDataboxRecord> {
       pricePerQuery: manifest.pricePerQuery,
       scriptHash: manifest.scriptHash,
       scriptEntrypoint: manifest.scriptEntrypoint,
+      schemaInterface: manifest.schemaInterface,
       coreVersion: manifest.coreVersion,
       corePlugins: manifest.corePlugins,
       storedDate,
@@ -85,6 +88,7 @@ export interface IDataboxRecord {
   pricePerQuery: number;
   paymentAddress: string;
   giftCardAddress: string;
+  schemaInterface: string;
   scriptHash: string;
   scriptEntrypoint: string;
   coreVersion: string;

--- a/databox/core/lib/LocalDataboxProcess.ts
+++ b/databox/core/lib/LocalDataboxProcess.ts
@@ -35,6 +35,7 @@ export default class LocalDataboxProcess extends TypedEventEmitter<{ error: Erro
     return {
       coreVersion: data.coreVersion,
       corePlugins: data.corePlugins,
+      schema: data.schema,
     };
   }
 

--- a/databox/core/package.json
+++ b/databox/core/package.json
@@ -10,6 +10,7 @@
     "@ulixee/databox": "2.0.0-alpha.12",
     "@ulixee/databox-interfaces": "2.0.0-alpha.12",
     "@ulixee/net": "2.0.0-alpha.12",
+    "@ulixee/schema": "2.0.0-alpha.12",
     "@ulixee/sidechain": "2.0.0-alpha.12",
     "@ulixee/specification": "2.0.0-alpha.12",
     "better-sqlite3": "^7.5.1",

--- a/databox/core/test/Databox.exec.test.ts
+++ b/databox/core/test/Databox.exec.test.ts
@@ -89,7 +89,7 @@ test('should be able run a databox', async () => {
   const packager = new DataboxPackager(`${__dirname}/databoxes/output.js`);
   await packager.build();
   await client.upload(await packager.dbx.asBuffer());
-  await expect(client.run(packager.manifest.versionHash, null)).resolves.toEqual({
+  await expect(client.exec(packager.manifest.versionHash, null)).resolves.toEqual({
     output: { success: true },
     metadata: expect.any(Object),
     latestVersionHash: expect.any(String),
@@ -112,7 +112,7 @@ test('should be able run a databox with payments', async () => {
   expect(manifest.pricePerQuery).toBe(1250);
   await client.upload(await dbx.asBuffer());
 
-  await expect(client.run(manifest.versionHash, null)).rejects.toThrowError('requires payment');
+  await expect(client.exec(manifest.versionHash, null)).rejects.toThrowError('requires payment');
   const sidechainClient = new SidechainClient('http://localhost:1337', {
     identity: clientIdentity,
     address,
@@ -135,7 +135,7 @@ test('should be able run a databox with payments', async () => {
 
   apiCalls.mockClear();
 
-  await expect(client.run(manifest.versionHash, null, payment)).resolves.toEqual({
+  await expect(client.exec(manifest.versionHash, null, payment)).resolves.toEqual({
     output: { success: true },
     metadata: {
       microgons: 1255,
@@ -196,7 +196,7 @@ test('should be able run a databox with a GiftCard', async () => {
   const payment = await userSidechainClient.createMicroPayment(meta);
   expect(payment.microgons).toBeGreaterThan(1250);
   expect(payment.isGiftCardBatch).toBe(true);
-  await expect(client.run(manifest.versionHash, null, payment)).resolves.toEqual({
+  await expect(client.exec(manifest.versionHash, null, payment)).resolves.toEqual({
     output: { success: true },
     metadata: expect.any(Object),
     latestVersionHash: expect.any(String),
@@ -204,7 +204,7 @@ test('should be able run a databox with a GiftCard', async () => {
 
   // follow-on test that you can disable giftCards
   DataboxCore.options.giftCardAddress = null;
-  await expect(client.run(manifest.versionHash, null, payment)).rejects.toThrowError(
+  await expect(client.exec(manifest.versionHash, null, payment)).rejects.toThrowError(
     'not accepting gift cards',
   );
 });

--- a/databox/core/test/Databox.upload.test.ts
+++ b/databox/core/test/Databox.upload.test.ts
@@ -33,6 +33,14 @@ afterAll(async () => {
 test('should be able upload a databox', async () => {
   await client.upload(dbxFile);
   expect(Fs.existsSync(storageDir)).toBeTruthy();
+  expect(manifest.schemaInterface).toBe(`{
+  output: {
+    /**
+     * Whether or not this test succeeded
+     */
+    upload: boolean;
+  };
+}`)
   expect(Fs.existsSync(`${storageDir}/upload@${manifest.versionHash}.dbx`)).toBeTruthy();
 });
 

--- a/databox/core/test/DataboxCore.test.ts
+++ b/databox/core/test/DataboxCore.test.ts
@@ -75,7 +75,12 @@ test('can get metadata about an uploaded databox', async () => {
     maxBytesPerQuery: expect.any(Number),
     maxPricePerQuery: 0,
     maxMilliseconds: expect.any(Number),
-    schema: null,
+    schemaInterface: `{
+  output: {
+    "is-valid"?: boolean;
+    success: boolean;
+  };
+}`,
   });
 });
 

--- a/databox/core/test/LocalDataboxProcess.test.ts
+++ b/databox/core/test/LocalDataboxProcess.test.ts
@@ -10,6 +10,27 @@ test('it can extract the databox runtime', async () => {
   expect(meta.coreVersion).toBe('1.0.0');
 });
 
+test('it can extract the databox schema', async () => {
+  const scriptPath = Path.resolve(__dirname, 'databoxes/schema.js');
+  const databoxProcess = new LocalDataboxProcess(scriptPath);
+  const meta = await databoxProcess.fetchMeta();
+  await databoxProcess.close();
+
+  expect(meta.schema).toEqual({
+    input: {
+      field: {
+        typeName: 'string',
+        minLength: 1,
+        description: 'a field you should use',
+      },
+    },
+    output: {
+      success: {
+        typeName: 'boolean',
+      },
+    },
+  });
+});
 
 test('it can run the databox and return output', async () => {
   const scriptPath = Path.resolve(__dirname, 'databoxes/output.js');

--- a/databox/core/test/databoxes/bootup.ts
+++ b/databox/core/test/databoxes/bootup.ts
@@ -1,5 +1,15 @@
+import { boolean } from '@ulixee/schema';
+
 const Databox = require('@ulixee/databox');
 
-module.exports = new Databox(databox => {
-  databox.output = { success: true };
+module.exports = new Databox({
+  run(databox) {
+    databox.output = { success: true };
+  },
+  schema: {
+    output: {
+      'is-valid': boolean({ optional: true }),
+      success: boolean(),
+    },
+  },
 });

--- a/databox/core/test/databoxes/schema.ts
+++ b/databox/core/test/databoxes/schema.ts
@@ -1,0 +1,16 @@
+import Databox from '@ulixee/databox';
+import { boolean, string } from '@ulixee/schema';
+
+export default new Databox({
+  run(databox) {
+    databox.output = { success: true };
+  },
+  schema: {
+    input: {
+      field: string({ minLength: 1, description: 'a field you should use' }),
+    },
+    output: {
+      success: boolean(),
+    },
+  },
+});

--- a/databox/core/test/databoxes/upload.ts
+++ b/databox/core/test/databoxes/upload.ts
@@ -1,5 +1,11 @@
-import Databox from "@ulixee/databox";
+import Databox from '@ulixee/databox';
+import { boolean } from '@ulixee/schema';
 
-export default new Databox(databox => {
-  databox.output = { upload: true }
+export default new Databox({
+  run(databox) {
+    databox.output = { upload: true };
+  },
+  schema: {
+    output: { upload: boolean({ description: 'Whether or not this test succeeded' }) },
+  },
 });

--- a/databox/examples/example.org.ts
+++ b/databox/examples/example.org.ts
@@ -1,6 +1,7 @@
 // NOTE: you must start your own Ulixee Server to run this example.
 
 import Databox from '@ulixee/databox-for-hero';
+import { string } from '@ulixee/schema';
 
 // configure input.url by running as node example.org.js --input.url="https://ulixee.org"
 
@@ -20,5 +21,14 @@ export default new Databox({
     output.body = await hero.document.body.textContent;
     console.log(`LOADED ${input.url}: ${title}`);
     await hero.close();
+  },
+  schema: {
+    input: {
+      url: string({ format: 'url' }),
+    },
+    output: {
+      title: string(),
+      body: string(),
+    },
   },
 });

--- a/databox/examples/extractStorage.ts
+++ b/databox/examples/extractStorage.ts
@@ -4,18 +4,21 @@ import Databox from '@ulixee/databox-for-hero';
 
 export default new Databox({
   async run({ hero }) {
-      await hero.goto('https://ulixee.org');
-      await hero.waitForPaintingStable();
-      await hero.setData('localStorage', await hero.getJsValue('JSON.stringify(localStorage)'));
-      await hero.setData('sessionStorage', await hero.getJsValue('JSON.stringify(sessionStorage)'));
-      await hero.setData('cookies', await hero.activeTab.cookieStorage.getItems());
-      await hero.setData('history', await hero.getJsValue(`history.length`));
-    },
+    await hero.goto('https://ulixee.org');
+    await hero.waitForPaintingStable();
+    await hero.setSnippet('localStorage', await hero.getJsValue('JSON.stringify(localStorage)'));
+    await hero.setSnippet(
+      'sessionStorage',
+      await hero.getJsValue('JSON.stringify(sessionStorage)'),
+    );
+    await hero.setSnippet('cookies', await hero.activeTab.cookieStorage.getItems());
+    await hero.setSnippet('history', await hero.getJsValue(`history.length`));
+  },
   async onAfterHeroCompletes({ heroReplay, output }) {
-    const localStorage = await heroReplay.getData('localStorage');
-    const sessionStorage = await heroReplay.getData('sessionStorage');
-    const cookies = await heroReplay.getData('cookies');
-    const history = await heroReplay.getData('history');
+    const localStorage = await heroReplay.getSnippet('localStorage');
+    const sessionStorage = await heroReplay.getSnippet('sessionStorage');
+    const cookies = await heroReplay.getSnippet('cookies');
+    const history = await heroReplay.getSnippet('history');
 
     output.rootStorage = {
       local: localStorage,

--- a/databox/interfaces/IDataboxInputOutput.ts
+++ b/databox/interfaces/IDataboxInputOutput.ts
@@ -1,0 +1,4 @@
+export default interface IDataboxInputOutput {
+  input: Record<string, any>;
+  output: Record<string, any> | any;
+}

--- a/databox/packager/lib/cliCommands.ts
+++ b/databox/packager/lib/cliCommands.ts
@@ -264,6 +264,7 @@ You can choose from the options below to link to the existing server versions or
           manifest.versionTimestamp,
           manifest.coreVersion,
           manifest.corePlugins,
+          manifest.schemaInterface,
           console.log,
         );
         await newManifest.save();

--- a/databox/packager/package.json
+++ b/databox/packager/package.json
@@ -12,6 +12,7 @@
     "@ulixee/databox-core": "2.0.0-alpha.12",
     "@ulixee/databox-interfaces": "2.0.0-alpha.12",
     "@ulixee/net": "2.0.0-alpha.12",
+    "@ulixee/schema": "2.0.0-alpha.12",
     "@ulixee/specification": "2.0.0-alpha.12",
     "rollup": "^2.74.1",
     "rollup-plugin-terser": "^7.0.2",

--- a/end-to-end/gift-cards/dataUser.ts
+++ b/end-to-end/gift-cards/dataUser.ts
@@ -39,7 +39,7 @@ export default async function main(
   const databoxClient = new DataboxApiClient(databoxHost);
   const databoxMeta = await databoxClient.getMeta(databoxHash);
   const payment = await sidechainClient.createMicroPayment(databoxMeta);
-  const result = await databoxClient.run(databoxHash, { test: 1 }, payment);
+  const result = await databoxClient.exec(databoxHash, { test: 1 }, payment);
 
   console.log('Result of databox query is:', result);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17019,6 +17019,11 @@ typescript@^4.5.5, typescript@^4.7.2, typescript@~4.7.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.3.tgz#8364b502d5257b540f9de4c40be84c98e23a129d"
   integrity sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==
 
+typescript@^4.7.4:
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
+  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+
 ua-parser-js@0.7.28, ua-parser-js@^0.7.18, ua-parser-js@^0.7.22, ua-parser-js@^0.7.24:
   version "0.7.28"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"


### PR DESCRIPTION
This PR adds the ability to "install" typescript interfaces for Databoxes.
- Cli command called "install" that will write the type into `@ulixee/databox/types`.
- Databox client "run" was renamed to exec and will type check commands. This can be used in Stream or as a reference point.
- Each installed type can be optionally aliased with a shorter name for retrieving the types from @ulixee/databox/types
 ```ts
import ITypes from '@ulixee/databox/types';

await client.exec<ITypes['aliasedName']>('dbx1234', { arg:1 });
```