### PR TITLE
fix(databox): fix databox replay w/o chromealive

### DIFF
--- a/apps/chromealive-core/index.ts
+++ b/apps/chromealive-core/index.ts
@@ -141,15 +141,14 @@ export default class ChromeAliveCore {
       return;
     }
 
-    if (heroSession.options.sessionResume?.sessionId) {
+    if (heroSession.options.resumeSessionId || heroSession.options.replaySessionId) {
       SourceMapSupport.resetCache();
     }
 
     if (heroSession.mode === 'browserless') {
-      // @ts-expect-error
-      const previousSessionId = heroSession.options.previousSessionId;
-      if (previousSessionId) {
-        const observer = this.sessionObserversById.get(previousSessionId);
+      const replaySessionId = heroSession.options.replaySessionId;
+      if (replaySessionId) {
+        const observer = this.sessionObserversById.get(replaySessionId);
         if (observer) observer.bindExtractor(heroSession);
         return;
       }
@@ -211,7 +210,7 @@ export default class ChromeAliveCore {
 
     const isRestartedSessionId =
       !!this.restartingHeroSessionId &&
-      this.restartingHeroSessionId === heroSession.options.sessionResume?.sessionId;
+      this.restartingHeroSessionId === heroSession.options.resumeSessionId;
     this.restartingHeroSessionId = null;
 
     if (!this.activeHeroSessionId || isRestartedSessionId) {

--- a/apps/chromealive-core/lib/SessionObserver.ts
+++ b/apps/chromealive-core/lib/SessionObserver.ts
@@ -181,14 +181,14 @@ export default class SessionObserver extends TypedEventEmitter<{
     const execPath = this.scriptInstanceMeta.execPath;
     const execArgv = this.scriptInstanceMeta.execArgv ?? [];
     const args = [
-      `--sessionResume.startLocation="${startLocation}"`,
-      `--sessionResume.sessionId="${this.heroSession.id}"`,
-      '--show-chrome-alive',
+      `--resumeSessionStartLocation="${startLocation}"`,
+      `--resumeSessionId="${this.heroSession.id}"`,
+      '--showChromeAlive',
     ];
     if (startLocation === 'extraction') {
       args.length = 0;
       this.resetExtraction();
-      args.push(`--previousSessionId="${this.heroSession.id}"`, '--mode="browserless"');
+      args.push(`--replaySessionId="${this.heroSession.id}"`, '--mode="browserless"');
     }
 
     try {

--- a/apps/chromealive-interfaces/apis/ISessionApi.ts
+++ b/apps/chromealive-interfaces/apis/ISessionApi.ts
@@ -7,7 +7,7 @@ import IAppModeEvent from '../events/IAppModeEvent';
 import ISessionSearchResult from '../ISessionSearchResult';
 
 export interface ISessionResumeArgs extends IHeroSessionArgs {
-  startLocation: ISessionCreateOptions['sessionResume']['startLocation'];
+  startLocation: ISessionCreateOptions['resumeSessionStartLocation'];
   startFromNavigationId?: number;
 }
 

--- a/databox/docs/DataboxBasics/OutputObject.md
+++ b/databox/docs/DataboxBasics/OutputObject.md
@@ -33,7 +33,7 @@ NOTE: you cannot "re-assign" the output variable and have it be observed. You sh
 import Databox from '@ulixee/databox-playground';
 
 export default new Databox(async databox => {
-  const { output } = databox;
+  let { output } = databox;
   
   // Setting a variable is ok
   output.whoop = 'This will work!';

--- a/databox/docs/DataboxForHero/UsingThePlugin.md
+++ b/databox/docs/DataboxForHero/UsingThePlugin.md
@@ -6,7 +6,7 @@ To use DataboxForHero, import the plugin and include it in the `plugins` array o
 
 ```js
 import Databox from '@ulixee/databox';
-import { DataboxForHeroPlugin } = '@ulixee/databox-for-hero';
+import { DataboxForHeroPlugin } from '@ulixee/databox-for-hero';
 
 export default new Databox({
   plugins: [DataboxForHeroPlugin],
@@ -20,7 +20,7 @@ export default new Databox({
 A simpler approach is use the DataboxForHero's default export, which automatically bundles the plugin. You can use it almost exactly the same as the standard Databox:
 
 ```js
-import DataboxForHero = '@ulixee/databox-for-hero';
+import DataboxForHero from '@ulixee/databox-for-hero';
 
 export default new DataboxForHero(async databox => {
   const { input, output, hero } = databox;

--- a/databox/docs/DataboxForPuppeteer/UsingThePlugin.md
+++ b/databox/docs/DataboxForPuppeteer/UsingThePlugin.md
@@ -6,7 +6,7 @@ To use DataboxForPuppeteer, import the plugin and include it in the `plugins` ar
 
 ```js
 import Databox from '@ulixee/databox';
-import { DataboxForPuppeteerPlugin } = '@ulixee/databox-for-puppeteer';
+import { DataboxForPuppeteerPlugin } from '@ulixee/databox-for-puppeteer';
 
 export default new Databox({
   plugins: [DataboxForPuppeteerPlugin],
@@ -25,7 +25,7 @@ export default new Databox({
 A simpler approach is use the DataboxForPuppeteer's default export, which automatically bundles the plugin. You can use it almost exactly the same as the standard Databox:
 
 ```js
-import DataboxForPuppeteer = '@ulixee/databox-for-puppeteer';
+import DataboxForPuppeteer from '@ulixee/databox-for-puppeteer';
 
 export default new DataboxForPuppeteer(async databox => {
   const { input, output, browser } = databox;

--- a/databox/for-hero/client/interfaces/IDataboxForHeroExecOptions.ts
+++ b/databox/for-hero/client/interfaces/IDataboxForHeroExecOptions.ts
@@ -1,8 +1,5 @@
 import IDataboxExecOptions from '@ulixee/databox-interfaces/IDataboxExecOptions';
 import { IHeroCreateOptions } from '@ulixee/hero';
 
-type IDataboxForHeroExecOptions<ISchema> = IDataboxExecOptions<ISchema> &
-  IHeroCreateOptions & {
-    previousSessionId?: string;
-  };
+type IDataboxForHeroExecOptions<ISchema> = IDataboxExecOptions<ISchema> & IHeroCreateOptions;
 export default IDataboxForHeroExecOptions;

--- a/databox/for-hero/client/test/basic.test.ts
+++ b/databox/for-hero/client/test/basic.test.ts
@@ -118,12 +118,11 @@ describe('basic Databox tests', () => {
       run: runFn,
       onAfterHeroCompletes: onAfterHeroCompletesFn,
     });
-    await databoxForHero.exec({ previousSessionId: '123' });
+    await databoxForHero.exec({ replaySessionId: '123' });
 
     expect(runFn).not.toHaveBeenCalled();
     expect(onAfterHeroCompletesFn).toHaveBeenCalledTimes(1);
   });
-
 
   it('receives DataboxMeta', async () => {
     const { databoxObject, databoxClose } = await Helpers.createFullstackDatabox();


### PR DESCRIPTION
Databox for Hero "replay" phase was only working if Chromealive was running. This PR fixes it so it will work on it's own (works with a Hero change)