### PR TITLE
Upgrade ulixee-cloud Docker base from Node 18 to Node 24 LTS

### DIFF
--- a/cloud/tools/docker/Dockerfile
+++ b/cloud/tools/docker/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:18-slim
+# Node 24 LTS (Krypton). Node 18 is EOL and blocks dependents from upgrading
+# packages that require Node >=20 (e.g. sharp@0.35+ for libvips CVE fixes).
+FROM node:24-slim
 
 ARG ADD_TO_INSTALL=true
 ARG VERSION
@@ -6,11 +8,15 @@ LABEL org.opencontainers.image.source=https://github.com/ulixee/platform
 LABEL org.opencontainers.image.description="The open data platform. This image packages Ulixee Cloud, Hero and the last 2 Chrome versions."
 LABEL org.opencontainers.image.licenses=MIT
 
-# fonts
-RUN echo "deb http://deb.debian.org/debian/ buster main contrib non-free" >> /etc/apt/sources.list \
+# Fonts + Chrome/Xvfb runtime deps. node:24-slim is Debian bookworm (DEB822
+# sources); enable contrib/non-free for ttf-mscorefonts-installer. fonts-wqy-zenhei
+# replaces the removed ttf-wqy-zenhei package from older Debian.
+# python3/make/g++ are needed to compile native modules (e.g. better-sqlite3)
+# when prebuilds are not yet published for this Node major.
+RUN sed -i 's/Components: main$/Components: main contrib non-free non-free-firmware/' /etc/apt/sources.list.d/debian.sources \
     && echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections \
     && apt-get update \
-    && apt-get install -y \
+    && apt-get install -y --no-install-recommends \
         fonts-arphic-ukai \
         fonts-arphic-uming \
         fonts-ipafont-mincho \
@@ -18,12 +24,16 @@ RUN echo "deb http://deb.debian.org/debian/ buster main contrib non-free" >> /et
         fonts-kacst \
         fonts-ipafont-gothic \
         fonts-unfonts-core \
-        ttf-wqy-zenhei \
+        fonts-wqy-zenhei \
         ttf-mscorefonts-installer \
         fonts-freefont-ttf \
         xvfb \
         git \
         curl \
+        ca-certificates \
+        python3 \
+        make \
+        g++ \
     && apt-get clean \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*

--- a/cloud/tools/docker/Dockerfile
+++ b/cloud/tools/docker/Dockerfile
@@ -64,5 +64,5 @@ RUN cd /app/ulixee && yarn init -yp \
 # Add below to run as unprivileged user. It's not included by default, but you can use docker run `--user ulixee`.
 # USER ulixee
 
-CMD npx @ulixee/cloud start
+CMD ["npx", "@ulixee/cloud", "start"]
 # To run this docker, please see ./run.sh


### PR DESCRIPTION
## Summary
- Bump `cloud/tools/docker/Dockerfile` from `node:18-slim` to `node:24-slim` (current Active LTS / Krypton).
- Update Debian package setup for Bookworm: enable `contrib`/`non-free` via DEB822 sources, replace removed `ttf-wqy-zenhei` with `fonts-wqy-zenhei`, drop the dead Buster apt mirror.
- Install `python3`/`make`/`g++` so native modules like `better-sqlite3` can compile when Node 24 prebuilds are not yet available.

Fixes #219

## Why
Node 18 is EOL. Downstream images based on `ghcr.io/ulixee/ulixee-cloud` cannot upgrade to `sharp@0.35+` (requires Node >=20.9), which is needed to clear known libvips CVEs (CVE-2026-33327, CVE-2026-33328, CVE-2026-35590, CVE-2026-35591).

## Test plan
Locally built and verified `ulixee-cloud:node24-test` with `@ulixee/cloud@2.0.0-alpha.34`:

- [x] `docker build` succeeds on `node:24-slim`
- [x] Image reports `node v24.19.0`
- [x] `better-sqlite3` loads successfully
- [x] `sharp@0.35.3` installs and encodes a PNG inside the image
- [x] `npx @ulixee/cloud start --port=1818` starts and logs `Ulixee Cloud listening at localhost:1818`